### PR TITLE
Adopt src-layout and rename the package to lowercase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[*.md]
+# Trailing whitespace is significant in Markdown line breaks.
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,18 @@ jobs:
 
       - name: Run tests
         run: uv run python -m unittest discover tests
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Verify the wheel ships the py.typed marker
+        run: |
+          uv run python - <<'PY'
+          import glob, sys, zipfile
+
+          wheel = sorted(glob.glob("dist/*.whl"))[-1]
+          names = zipfile.ZipFile(wheel).namelist()
+          if "pyfetch/py.typed" not in names:
+              sys.exit(f"py.typed missing from {wheel}: {names}")
+          print(f"{wheel} ships py.typed")
+          PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-07-23
+
+### Changed
+
+- **BREAKING**: the import package is now `pyfetch`, not `PyFetch`, per PEP 8
+  ("Python packages should also have short, all-lowercase names"). Update
+  imports from `from PyFetch import HTTPClient` to `from pyfetch import
+  HTTPClient`. The distribution name, the console script, and the built wheel
+  were already lowercase, so only the import path changes. No compatibility
+  shim is provided.
+- Moved the package under `src/`, following the PyPA src-layout recommendation.
+  Tests now exercise the installed package rather than the working directory.
+- The `pyfetch` console script now points at `pyfetch.__main__:run` instead of
+  `pyfetch.cli:main`, so it handles `Ctrl+C` the same way `python -m pyfetch`
+  always did. Previously the console script exited with a traceback.
+- `argparse` usage output is pinned to `pyfetch` rather than deriving from
+  `sys.argv[0]`.
+
+### Added
+
+- A PEP 561 `py.typed` marker. The package has been `mypy --strict` clean for
+  some time, but without this marker downstream type checkers ignored all of
+  its annotations.
+- `CONTRIBUTING.md`, `CHANGELOG.md`, and `.editorconfig`.
+
+## [1.1.0] - 2026-07-23
+
+### Changed
+
+- The client keeps a pooled `requests.Session` for its lifetime, so repeat
+  requests to a host reuse the TCP/TLS connection. A repeat HTTPS request went
+  from 24.5 ms to 6.2 ms; 200 requests now open 1 connection instead of 200.
+- Retries moved to a urllib3 `Retry` on the session adapter, with exponential
+  backoff and `Retry-After` support. Only connection failures and transient
+  statuses (408, 425, 429, 500, 502, 503, 504) are retried; a `404` now costs
+  one round trip instead of three. Read failures and retryable statuses are not
+  retried for `POST`/`PATCH`; connection failures are retried for every method,
+  because a request that never reached the server cannot have been acted on
+  twice.
+- `GET` no longer forces `stream=True` unless `--progress` is passed.
+- `HTTPClient` now owns a connection and should be closed; it supports the
+  context manager protocol and a `close()` method.
+- `DOWNLOAD_CHUNK_SIZE` raised from 8 KiB to 64 KiB.
+- CLI start-up fell from 238 ms to 80 ms: `HTTPClient` resolves lazily via
+  PEP 562 and `tqdm` is imported only when a progress bar is drawn, so the help
+  paths no longer import `requests`.
+
+### Added
+
+- Optional `speedups` extra (`zstandard`, `brotli`) enabling Zstandard and
+  Brotli transfer compression.
+- Support declared and tested for Python 3.12, 3.13, and 3.14.
+
+## [1.0.0]
+
+- Initial release.
+
+[2.0.0]: https://github.com/maltemindedal/pyfetch/releases/tag/v2.0.0
+[1.1.0]: https://github.com/maltemindedal/pyfetch/releases/tag/v1.1.0
+[1.0.0]: https://github.com/maltemindedal/pyfetch/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to PyFetch
+
+## Project layout
+
+```
+src/pyfetch/        The package. src-layout, so tests run against the
+                    installed distribution rather than the working directory.
+  __init__.py       Public API. Resolves HTTPClient lazily (PEP 562).
+  __main__.py       `python -m pyfetch` and the `pyfetch` console script.
+  cli.py            Argument parsing and response rendering.
+  http_client.py    The HTTP client, session pooling, and retry policy.
+  exceptions.py     Exception hierarchy.
+  py.typed          PEP 561 marker.
+tests/              One test module per source module: test_<module>.py.
+```
+
+Conventions:
+
+- Package and module names are short and all-lowercase (PEP 8). The import
+  package is `pyfetch`; there is no `PyFetch`.
+- Every public module, class, and function carries a docstring.
+- Imports of first-party code are absolute (`from pyfetch.exceptions import ...`),
+  never relative.
+- Anything that would import `requests` at module scope should be deferred, so
+  that the CLI's help paths stay fast. `tests/test_cli.py` guards this.
+
+## Getting set up
+
+```bash
+uv sync --group dev --extra speedups
+```
+
+## Before opening a pull request
+
+All four must pass; CI runs them on Python 3.10 through 3.14.
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy .
+uv run python -m unittest discover tests
+```
+
+To apply formatting: `uv run ruff format .`
+
+## Testing notes
+
+Type checking runs in `mypy --strict` over both `src/` and `tests/`.
+
+Do not mock `requests.Session.request` when the behaviour under test involves
+retries. That mock sits *above* the adapter where urllib3's retry logic lives,
+so it cannot observe retries at all — an earlier revision shipped a false claim
+about `POST` retry behaviour on exactly that mistake. Use
+`TestRetryAgainstRealServer`, which counts requests arriving at a real socket,
+or assert against `urllib3.util.retry.Retry` directly.
+
+## Changelog
+
+User-visible changes go in `CHANGELOG.md` under an `Unreleased` heading,
+following Keep a Changelog. The project follows semantic versioning; the import
+package name is part of the public API, so renaming it is a major bump.

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ uv sync --extra speedups
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/maltemindedal/PyFetch.git
-cd PyFetch
+git clone https://github.com/maltemindedal/pyfetch.git
+cd pyfetch
 ```
 
 2. Sync the project dependencies:
@@ -109,6 +109,39 @@ uv sync --group dev
 uv run pyfetch HELP
 ```
 
+## Project Layout
+
+The package uses the [src-layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/)
+recommended by the PyPA, so tests exercise the installed distribution rather
+than whatever happens to sit in the working directory.
+
+```
+src/pyfetch/        The package (import name: `pyfetch`)
+  __init__.py       Public API; resolves HTTPClient lazily (PEP 562)
+  __main__.py       `python -m pyfetch` and the `pyfetch` console script
+  cli.py            Argument parsing and response rendering
+  http_client.py    HTTP client, session pooling, retry policy
+  exceptions.py     Exception hierarchy
+  py.typed          PEP 561 marker
+tests/              One module per source module: test_<module>.py
+```
+
+The package is fully typed and ships a `py.typed` marker, so downstream type
+checkers use its annotations without extra configuration.
+
+## Upgrading from 1.x
+
+The import package was renamed from `PyFetch` to `pyfetch` in 2.0.0 to follow
+PEP 8. The distribution name, the console script, and the built wheel were
+already lowercase, so only the import path changes:
+
+```python
+from PyFetch import HTTPClient  # 1.x
+from pyfetch import HTTPClient  # 2.0+
+```
+
+There is no compatibility shim. See [CHANGELOG.md](CHANGELOG.md) for the rest.
+
 ## Library Usage
 
 You can also use PyFetch as a library in your Python projects.
@@ -118,7 +151,7 @@ You can also use PyFetch as a library in your Python projects.
 First, import and create an instance of the `HTTPClient`:
 
 ```python
-from PyFetch import HTTPClient
+from pyfetch import HTTPClient
 
 client = HTTPClient(timeout=30, retries=3, verbose=False)
 ```
@@ -154,7 +187,7 @@ print(response.json())
 The client raises specific exceptions for different types of errors:
 
 ```python
-from PyFetch.exceptions import HTTPClientError, HTTPConnectionError
+from pyfetch.exceptions import HTTPClientError, HTTPConnectionError
 
 try:
     response = client.get("https://a-non-existent-domain.com")
@@ -252,7 +285,7 @@ Tests are organized in three main files:
 - `tests/test_http_client.py` - HTTP client functionality tests
 - `tests/test_exceptions.py` - Exception handling tests
 
-Typing is enforced with `mypy` in strict mode across both `PyFetch/` and `tests/`.
+Typing is enforced with `mypy` in strict mode across both `src/` and `tests/`.
 
 To add new tests:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "PyFetch"
-version = "1.1.0"
+name = "pyfetch"
+version = "2.0.0"
 description = "A simple HTTP CLI client"
 readme = "README.md"
 license = "Apache-2.0"
@@ -28,10 +28,17 @@ dependencies = ["requests>=2.33.1", "tqdm>=4.66.0", "urllib3>=2.7.0"]
 speedups = ["zstandard>=0.23", "brotli>=1.1"]
 
 [project.scripts]
-pyfetch = "PyFetch.cli:main"
+# Points at `run`, not `cli:main`, so the console script gets the same
+# KeyboardInterrupt handling as `python -m pyfetch`.
+pyfetch = "pyfetch.__main__:run"
 
 [tool.setuptools.packages.find]
-include = ["PyFetch", "PyFetch.*"]
+where = ["src"]
+include = ["pyfetch", "pyfetch.*"]
+
+[tool.setuptools.package-data]
+# PEP 561: ship the marker so downstream type checkers use our annotations.
+pyfetch = ["py.typed"]
 
 [dependency-groups]
 dev = ["mypy>=1.13,<2", "ruff>=0.11.5,<0.12", "types-requests>=2.33.0,<3"]
@@ -39,7 +46,11 @@ dev = ["mypy>=1.13,<2", "ruff>=0.11.5,<0.12", "types-requests>=2.33.0,<3"]
 [tool.mypy]
 python_version = "3.10"
 strict = true
-files = ["PyFetch", "tests"]
+files = ["src", "tests"]
+mypy_path = "src"
+# Build output duplicates the package; without this, `mypy .` after a build
+# fails with "Duplicate module named 'pyfetch'".
+exclude = ["^build/", "^dist/"]
 
 [[tool.mypy.overrides]]
 module = ["tqdm"]
@@ -48,10 +59,14 @@ ignore_missing_imports = true
 [tool.ruff]
 target-version = "py310"
 line-length = 88
+src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "C4", "SIM", "RUF", "PERF"]
 ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pyfetch"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/pyfetch/__init__.py
+++ b/src/pyfetch/__init__.py
@@ -6,7 +6,7 @@ command-line tool and as a library in other Python applications.
 
 `HTTPClient` is resolved lazily (PEP 562) so that importing this package -- or
 running the CLI's help paths -- does not pull in `requests`, which costs well
-over 100 ms of interpreter start-up on its own. `from PyFetch import HTTPClient`
+over 100 ms of interpreter start-up on its own. `from pyfetch import HTTPClient`
 keeps working exactly as before and imports the stack on first access.
 
 Public API:
@@ -18,12 +18,12 @@ Public API:
 
 from typing import TYPE_CHECKING, Any
 
-from PyFetch.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
+from pyfetch.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
 
 if TYPE_CHECKING:
-    from PyFetch.http_client import HTTPClient
+    from pyfetch.http_client import HTTPClient
 
-__version__ = "1.1.0"
+__version__ = "2.0.0"
 
 __all__ = [
     "HTTPClient",
@@ -37,7 +37,7 @@ __all__ = [
 def __getattr__(name: str) -> Any:
     """Resolves `HTTPClient` on first access, deferring the `requests` import."""
     if name == "HTTPClient":
-        from PyFetch.http_client import HTTPClient
+        from pyfetch.http_client import HTTPClient
 
         return HTTPClient
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/pyfetch/__main__.py
+++ b/src/pyfetch/__main__.py
@@ -1,13 +1,13 @@
-"""Main entry point for the PyFetch command-line application.
+"""Main entry point for the pyfetch command-line application.
 
-This module allows the PyFetch application to be executed as a package
-by running `python -m PyFetch`. It handles the initial execution and
+This module allows the pyfetch application to be executed as a package
+by running `python -m pyfetch`. It handles the initial execution and
 catches common exceptions like `KeyboardInterrupt`.
 """
 
 import sys
 
-from PyFetch.cli import main
+from pyfetch.cli import main
 
 
 def run() -> None:

--- a/src/pyfetch/cli.py
+++ b/src/pyfetch/cli.py
@@ -1,7 +1,7 @@
 """Command-line interface for making HTTP requests.
 
 This module provides a command-line interface (CLI) for making HTTP requests
-using the PyFetch HTTP client. It supports common HTTP methods, custom headers,
+using the pyfetch HTTP client. It supports common HTTP methods, custom headers,
 JSON data, and other features.
 
 The HTTP client (and with it ``requests``) is imported lazily so that ``--help``,
@@ -17,7 +17,7 @@ import textwrap
 from collections.abc import Sequence
 from typing import Any, NamedTuple, TypedDict
 
-from PyFetch.exceptions import HTTPClientError
+from pyfetch.exceptions import HTTPClientError
 
 
 class RequestKwargs(TypedDict, total=False):
@@ -87,7 +87,7 @@ COMMANDS: tuple[Command, ...] = (
 
 
 def show_examples(suppress_output: bool = False) -> str:
-    """Prints usage examples for the PyFetch CLI.
+    """Prints usage examples for the pyfetch CLI.
 
     This function displays a list of common commands to guide the user.
 
@@ -205,6 +205,9 @@ def create_parser() -> argparse.ArgumentParser:
         argparse.ArgumentParser: The configured argument parser.
     """
     parser = argparse.ArgumentParser(
+        # Pinned so `pyfetch`, `python -m pyfetch`, and a direct script call all
+        # print the same usage line instead of echoing the interpreter path.
+        prog="pyfetch",
         description="HTTP CLI client supporting GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS methods",
         formatter_class=CustomFormatter,
         add_help=True,
@@ -241,7 +244,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None, suppress_output: bool = False) -> None:
-    """The main entry point for the PyFetch CLI.
+    """The main entry point for the pyfetch CLI.
 
     This function parses command-line arguments, initializes the HTTP client,
     and executes the requested HTTP command. It also handles response printing
@@ -265,7 +268,7 @@ def main(argv: Sequence[str] | None = None, suppress_output: bool = False) -> No
         return
 
     # Deferred so the help paths above never import the HTTP stack.
-    from PyFetch.http_client import HTTPClient
+    from pyfetch.http_client import HTTPClient
 
     try:
         kwargs = _parse_request_kwargs(args)

--- a/src/pyfetch/exceptions.py
+++ b/src/pyfetch/exceptions.py
@@ -1,12 +1,12 @@
-"""Custom exceptions for the PyFetch HTTP client.
+"""Custom exceptions for the pyfetch HTTP client.
 
 This module defines a hierarchy of custom exceptions to provide more specific
-error information when using the PyFetch client.
+error information when using the pyfetch client.
 """
 
 
 class HTTPClientError(Exception):
-    """Base exception for all errors raised by the PyFetch client.
+    """Base exception for all errors raised by the pyfetch client.
 
     This exception serves as the base for more specific client-related errors,
     allowing for consolidated error handling.

--- a/src/pyfetch/http_client.py
+++ b/src/pyfetch/http_client.py
@@ -18,7 +18,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from PyFetch.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
+from pyfetch.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
 
 
 class ProgressBar(Protocol):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from PyFetch.cli import main, show_examples
+from pyfetch.cli import main, show_examples
 
 
 class TestCLI(unittest.TestCase):
@@ -39,7 +39,7 @@ class TestCLI(unittest.TestCase):
             main(["HELP"], suppress_output=True)
             self.assertEqual("", fake_stdout.getvalue())
 
-    @patch("PyFetch.http_client.HTTPClient.get")
+    @patch("pyfetch.http_client.HTTPClient.get")
     def test_get_command(self, mock_get: MagicMock) -> None:
         """Test the GET command."""
         mock_get.return_value = self._build_response(text="Success")
@@ -53,7 +53,7 @@ class TestCLI(unittest.TestCase):
         self.assertIn("Response Body:", output)
         self.assertIn("Success", output)
 
-    @patch("PyFetch.http_client.HTTPClient.post")
+    @patch("pyfetch.http_client.HTTPClient.post")
     def test_post_command(self, mock_post: MagicMock) -> None:
         """Test the POST command."""
         mock_post.return_value = self._build_response(
@@ -73,7 +73,7 @@ class TestCLI(unittest.TestCase):
             json={"key": "value"},
         )
 
-    @patch("PyFetch.http_client.HTTPClient.post")
+    @patch("pyfetch.http_client.HTTPClient.post")
     def test_progress_is_not_available_for_post(self, mock_post: MagicMock) -> None:
         """Test that --progress is not available for POST command."""
         mock_post.return_value.text = "{}"
@@ -99,7 +99,7 @@ class TestCLI(unittest.TestCase):
 
         self.assertIn("Invalid JSON data", fake_stdout.getvalue())
 
-    @patch("PyFetch.http_client.HTTPClient.get")
+    @patch("pyfetch.http_client.HTTPClient.get")
     def test_suppress_output_hides_response_text(self, mock_get: MagicMock) -> None:
         """Test suppress_output keeps stdout clean during command execution."""
         mock_get.return_value = self._build_response(text="Success")
@@ -109,10 +109,16 @@ class TestCLI(unittest.TestCase):
 
         self.assertEqual("", fake_stdout.getvalue())
 
+    def test_usage_line_is_stable_across_entry_points(self) -> None:
+        """Test help output names the command, not whatever launched it."""
+        from pyfetch.cli import create_parser
+
+        self.assertTrue(create_parser().format_usage().startswith("usage: pyfetch"))
+
     def test_help_path_does_not_import_requests(self) -> None:
         """Guard the start-up win: help must not drag in the HTTP stack."""
         probe = (
-            "import sys; from PyFetch.cli import main; main(['HELP'], True);"
+            "import sys; from pyfetch.cli import main; main(['HELP'], True);"
             " sys.exit(1 if 'requests' in sys.modules else 0)"
         )
         result = subprocess.run(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unittest
 
-from PyFetch.exceptions import HTTPClientError
+from pyfetch.exceptions import HTTPClientError
 
 
 class TestHTTPClientError(unittest.TestCase):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -15,8 +15,8 @@ import requests
 from urllib3.exceptions import ConnectTimeoutError, ReadTimeoutError
 from urllib3.util.retry import Retry
 
-from PyFetch.exceptions import HTTPConnectionError, ResponseError
-from PyFetch.http_client import HTTPClient
+from pyfetch.exceptions import HTTPConnectionError, ResponseError
+from pyfetch.http_client import HTTPClient
 
 SESSION_REQUEST = "requests.Session.request"
 

--- a/uv.lock
+++ b/uv.lock
@@ -355,7 +355,7 @@ wheels = [
 
 [[package]]
 name = "pyfetch"
-version = "1.1.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

Audited the repo layout against PEP 8 and PyPA packaging guidance. Seven findings; **two were real defects, not style.**

## Verified defects

**1. The console script and `python -m` diverged.** `[project.scripts]` pointed at `PyFetch.cli:main`, bypassing `__main__.run()`. Measured before the fix:

| Entry point | Ctrl+C behaviour |
|---|---|
| `pyfetch GET ...` | raw traceback, exit `0xC000013A` |
| `python -m PyFetch` | `Operation cancelled by user`, exit 0 |

Two entry points, two behaviours. The entry point now targets `pyfetch.__main__:run`; both paths are identical.

**2. No PEP 561 marker.** The package has been `mypy --strict` clean for a while, but without `py.typed` every downstream type checker silently ignored all of its annotations. Added, plus a CI step asserting it actually ships in the wheel.

## Convention fixes

**3. The package directory was CapWords.** PEP 8: *"Python packages should also have short, all-lowercase names."* `PyFetch/` was the sole outlier — the repo directory, the GitHub remote, the console script, and the built wheel (`pyfetch-1.1.0-py3-none-any.whl`, normalized per PEP 503/625) were all lowercase already.

**4. Flat layout rather than `src/`.** Without src-layout, `import PyFetch` from the repo root resolves to the source tree rather than the installed package, so tests can pass against code that was never installed.

**5–7.** Added `CHANGELOG.md`, `CONTRIBUTING.md`, `.editorconfig`. Pinned argparse `prog="pyfetch"` — the console script previously rendered its usage line as the interpreter path.

## Layout

```
src/pyfetch/        The package (import name: `pyfetch`)
  __init__.py       Public API; resolves HTTPClient lazily (PEP 562)
  __main__.py       `python -m pyfetch` and the `pyfetch` console script
  cli.py            Argument parsing and response rendering
  http_client.py    HTTP client, session pooling, retry policy
  exceptions.py     Exception hierarchy
  py.typed          PEP 561 marker
tests/              One module per source module: test_<module>.py
```

## Breaking change

The import package is renamed. Bumped to **2.0.0**; no compatibility shim, per the decision to keep the tree clean:

```python
from PyFetch import HTTPClient  # 1.x
from pyfetch import HTTPClient  # 2.0+
```

Only the import path changes — the distribution name, console script, and wheel name are unaffected because they already normalized to lowercase.

## Also fixed

`mypy` now excludes `build/` and `dist/`. Without it, running a build and then `mypy .` fails with `Duplicate module named "pyfetch"` — which I hit during this work.

## Testing

- ruff, `ruff format --check`, mypy strict all clean.
- **38 tests pass** (added a guard that the usage line stays `usage: pyfetch`).
- 10-case end-to-end CLI smoke run passes.
- Wheel builds as `pyfetch-2.0.0-py3-none-any.whl` and contains `pyfetch/py.typed`; CI now enforces this.
- Ctrl+C parity verified on both entry points.
- **Benchmarks unchanged** — 0.60 ms/request local, 82 ms CLI start-up. This is a pure restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
