### PR TITLE
Rename the project to Snaffle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
           wheel = sorted(glob.glob("dist/*.whl"))[-1]
           names = zipfile.ZipFile(wheel).namelist()
-          if "pyfetch/py.typed" not in names:
+          if "snaffle/py.typed" not in names:
               sys.exit(f"py.typed missing from {wheel}: {names}")
           print(f"{wheel} ships py.typed")
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,41 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING**: the project is renamed from PyFetch to **Snaffle**. The import
-  package, the distribution, and the console script are all now `snaffle`:
+- **BREAKING**: the project is named Snaffle. The import package, the
+  distribution, and the console script are all `snaffle`:
 
   ```python
-  from pyfetch import HTTPClient   # 2.x
-  from snaffle import HTTPClient   # 3.0+
+  from snaffle import HTTPClient
   ```
 
   ```bash
-  pyfetch GET https://example.com   # 2.x
-  snaffle GET https://example.com   # 3.0+
+  snaffle GET https://example.com
   ```
-
-  No compatibility shim is provided. The old name was both unavailable on PyPI
-  (held by an unrelated system-information tool) and semantically misleading,
-  since `*fetch` names in that space denote `neofetch`-style system reporters
-  rather than HTTP clients. "Snaffle" is British slang for grabbing something
-  quickly, which is what the tool does.
-- The GitHub repository moved to `maltemindedal/snaffle`. GitHub redirects the
-  old URL, but update your remotes.
 
 ## [2.0.0] - 2026-07-23
 
 ### Changed
 
-- **BREAKING**: the import package became `pyfetch` rather than `PyFetch`, per
-  PEP 8 ("Python packages should also have short, all-lowercase names"). The
-  distribution name, the console script, and the built wheel were already
-  lowercase, so only the import path changed. No compatibility shim was
-  provided.
+- **BREAKING**: the import package is all-lowercase, per PEP 8 ("Python
+  packages should also have short, all-lowercase names").
 - Moved the package under `src/`, following the PyPA src-layout recommendation.
   Tests now exercise the installed package rather than the working directory.
-- The console script began pointing at `__main__:run` instead of `cli:main`, so
-  it handles `Ctrl+C` the same way `python -m` always did. Previously the
-  console script exited with a traceback.
+- The console script points at `__main__:run` instead of `cli:main`, so it
+  handles `Ctrl+C` the same way `python -m` always did. Previously the console
+  script exited with a traceback.
 - `argparse` usage output is pinned to the command name rather than deriving
   from `sys.argv[0]`.
 
@@ -84,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 
-- Initial release, as PyFetch.
+- Initial release.
 
 [3.0.0]: https://github.com/maltemindedal/snaffle/releases/tag/v3.0.0
 [2.0.0]: https://github.com/maltemindedal/snaffle/releases/tag/v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,51 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-07-23
+
+### Changed
+
+- **BREAKING**: the project is renamed from PyFetch to **Snaffle**. The import
+  package, the distribution, and the console script are all now `snaffle`:
+
+  ```python
+  from pyfetch import HTTPClient   # 2.x
+  from snaffle import HTTPClient   # 3.0+
+  ```
+
+  ```bash
+  pyfetch GET https://example.com   # 2.x
+  snaffle GET https://example.com   # 3.0+
+  ```
+
+  No compatibility shim is provided. The old name was both unavailable on PyPI
+  (held by an unrelated system-information tool) and semantically misleading,
+  since `*fetch` names in that space denote `neofetch`-style system reporters
+  rather than HTTP clients. "Snaffle" is British slang for grabbing something
+  quickly, which is what the tool does.
+- The GitHub repository moved to `maltemindedal/snaffle`. GitHub redirects the
+  old URL, but update your remotes.
+
 ## [2.0.0] - 2026-07-23
 
 ### Changed
 
-- **BREAKING**: the import package is now `pyfetch`, not `PyFetch`, per PEP 8
-  ("Python packages should also have short, all-lowercase names"). Update
-  imports from `from PyFetch import HTTPClient` to `from pyfetch import
-  HTTPClient`. The distribution name, the console script, and the built wheel
-  were already lowercase, so only the import path changes. No compatibility
-  shim is provided.
+- **BREAKING**: the import package became `pyfetch` rather than `PyFetch`, per
+  PEP 8 ("Python packages should also have short, all-lowercase names"). The
+  distribution name, the console script, and the built wheel were already
+  lowercase, so only the import path changed. No compatibility shim was
+  provided.
 - Moved the package under `src/`, following the PyPA src-layout recommendation.
   Tests now exercise the installed package rather than the working directory.
-- The `pyfetch` console script now points at `pyfetch.__main__:run` instead of
-  `pyfetch.cli:main`, so it handles `Ctrl+C` the same way `python -m pyfetch`
-  always did. Previously the console script exited with a traceback.
-- `argparse` usage output is pinned to `pyfetch` rather than deriving from
-  `sys.argv[0]`.
+- The console script began pointing at `__main__:run` instead of `cli:main`, so
+  it handles `Ctrl+C` the same way `python -m` always did. Previously the
+  console script exited with a traceback.
+- `argparse` usage output is pinned to the command name rather than deriving
+  from `sys.argv[0]`.
 
 ### Added
 
-- A PEP 561 `py.typed` marker. The package has been `mypy --strict` clean for
+- A PEP 561 `py.typed` marker. The package had been `mypy --strict` clean for
   some time, but without this marker downstream type checkers ignored all of
   its annotations.
 - `CONTRIBUTING.md`, `CHANGELOG.md`, and `.editorconfig`.
@@ -60,8 +84,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 
-- Initial release.
+- Initial release, as PyFetch.
 
-[2.0.0]: https://github.com/maltemindedal/pyfetch/releases/tag/v2.0.0
-[1.1.0]: https://github.com/maltemindedal/pyfetch/releases/tag/v1.1.0
-[1.0.0]: https://github.com/maltemindedal/pyfetch/releases/tag/v1.0.0
+[3.0.0]: https://github.com/maltemindedal/snaffle/releases/tag/v3.0.0
+[2.0.0]: https://github.com/maltemindedal/snaffle/releases/tag/v2.0.0
+[1.1.0]: https://github.com/maltemindedal/snaffle/releases/tag/v1.1.0
+[1.0.0]: https://github.com/maltemindedal/snaffle/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to PyFetch
+# Contributing to Snaffle
 
 ## Project layout
 
 ```
-src/pyfetch/        The package. src-layout, so tests run against the
+src/snaffle/        The package. src-layout, so tests run against the
                     installed distribution rather than the working directory.
   __init__.py       Public API. Resolves HTTPClient lazily (PEP 562).
-  __main__.py       `python -m pyfetch` and the `pyfetch` console script.
+  __main__.py       `python -m snaffle` and the `snaffle` console script.
   cli.py            Argument parsing and response rendering.
   http_client.py    The HTTP client, session pooling, and retry policy.
   exceptions.py     Exception hierarchy.
@@ -17,9 +17,9 @@ tests/              One test module per source module: test_<module>.py.
 Conventions:
 
 - Package and module names are short and all-lowercase (PEP 8). The import
-  package is `pyfetch`; there is no `PyFetch`.
+  package is `snaffle`; there is no `Snaffle`.
 - Every public module, class, and function carries a docstring.
-- Imports of first-party code are absolute (`from pyfetch.exceptions import ...`),
+- Imports of first-party code are absolute (`from snaffle.exceptions import ...`),
   never relative.
 - Anything that would import `requests` at module scope should be deferred, so
   that the CLI's help paths stay fast. `tests/test_cli.py` guards this.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
-# PyFetch: A Lightweight HTTP CLI and Library
+# Snaffle: A Lightweight HTTP CLI and Library
+
+> **snaffle** _(verb, informal, British)_ — to take something for oneself,
+> typically quickly or without permission.
+>
+> _"Snaffle it off the server."_
 
 A lightweight command-line interface and Python library for making HTTP requests.
 Built with Python, this tool provides an easy way to make GET, POST, PUT, PATCH,
 DELETE, HEAD, and OPTIONS requests with support for JSON data, customizable timeouts,
 automatic retries on failures, and a verbose mode for detailed logging.
+
+```bash
+snaffle GET https://httpbin.org/get
+```
 
 ## Features
 
@@ -36,7 +45,7 @@ against `https://example.com` (median of 6 requests) and a local server:
 | 100 sequential local GETs (per request) | 1.47 ms | 0.57 ms |
 | TCP connections opened per 200 requests | 200     | 1       |
 | Request returning a 404                 | 4.78 ms | 0.60 ms |
-| CLI start-up (`pyfetch HELP`)           | 238 ms  | 80 ms   |
+| CLI start-up (`snaffle HELP`)           | 238 ms  | 80 ms   |
 
 Behaviours that changed to get there:
 
@@ -56,7 +65,7 @@ Behaviours that changed to get there:
 
 urllib3 applies its idempotent-method filter to read errors and to retryable
 statuses, but **not** to connection errors. That asymmetry is deliberate, and
-PyFetch keeps it:
+Snaffle keeps it:
 
 | Failure                              | `GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS` | `POST`, `PATCH` |
 | ------------------------------------ | ----------------------------------------- | --------------- |
@@ -93,8 +102,8 @@ uv sync --extra speedups
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/maltemindedal/pyfetch.git
-cd pyfetch
+git clone https://github.com/maltemindedal/snaffle.git
+cd snaffle
 ```
 
 2. Sync the project dependencies:
@@ -106,7 +115,7 @@ uv sync --group dev
 3. Run the CLI from the managed environment:
 
 ```bash
-uv run pyfetch HELP
+uv run snaffle HELP
 ```
 
 ## Project Layout
@@ -116,9 +125,9 @@ recommended by the PyPA, so tests exercise the installed distribution rather
 than whatever happens to sit in the working directory.
 
 ```
-src/pyfetch/        The package (import name: `pyfetch`)
+src/snaffle/        The package (import name: `snaffle`)
   __init__.py       Public API; resolves HTTPClient lazily (PEP 562)
-  __main__.py       `python -m pyfetch` and the `pyfetch` console script
+  __main__.py       `python -m snaffle` and the `snaffle` console script
   cli.py            Argument parsing and response rendering
   http_client.py    HTTP client, session pooling, retry policy
   exceptions.py     Exception hierarchy
@@ -129,29 +138,35 @@ tests/              One module per source module: test_<module>.py
 The package is fully typed and ships a `py.typed` marker, so downstream type
 checkers use its annotations without extra configuration.
 
-## Upgrading from 1.x
+## Upgrading from PyFetch
 
-The import package was renamed from `PyFetch` to `pyfetch` in 2.0.0 to follow
-PEP 8. The distribution name, the console script, and the built wheel were
-already lowercase, so only the import path changes:
+This project was called PyFetch through 2.x. In 3.0.0 the package, the
+distribution, and the command all became `snaffle`:
 
 ```python
-from PyFetch import HTTPClient  # 1.x
-from pyfetch import HTTPClient  # 2.0+
+from pyfetch import HTTPClient   # 2.x
+from snaffle import HTTPClient   # 3.0+
 ```
 
-There is no compatibility shim. See [CHANGELOG.md](CHANGELOG.md) for the rest.
+```bash
+pyfetch GET https://example.com   # 2.x
+snaffle GET https://example.com   # 3.0+
+```
+
+There is no compatibility shim. Earlier still, 2.0.0 renamed the import package
+from `PyFetch` to `pyfetch` for PEP 8. See [CHANGELOG.md](CHANGELOG.md) for the
+full history.
 
 ## Library Usage
 
-You can also use PyFetch as a library in your Python projects.
+You can also use Snaffle as a library in your Python projects.
 
 ### Creating a Client
 
 First, import and create an instance of the `HTTPClient`:
 
 ```python
-from pyfetch import HTTPClient
+from snaffle import HTTPClient
 
 client = HTTPClient(timeout=30, retries=3, verbose=False)
 ```
@@ -187,7 +202,7 @@ print(response.json())
 The client raises specific exceptions for different types of errors:
 
 ```python
-from pyfetch.exceptions import HTTPClientError, HTTPConnectionError
+from snaffle.exceptions import HTTPClientError, HTTPConnectionError
 
 try:
     response = client.get("https://a-non-existent-domain.com")
@@ -203,37 +218,37 @@ except HTTPClientError as e:
 
 ```bash
 # 1. Normal GET request:
-pyfetch GET https://httpbin.org/get
+snaffle GET https://httpbin.org/get
 
 # 2. GET request with progress bar (for files larger than 5MB):
-pyfetch GET https://example.com/large-file.zip --progress
+snaffle GET https://example.com/large-file.zip --progress
 
 # 3. GET request with verbose mode to see retry logs and detailed output:
-pyfetch GET https://httpbin.org/get --verbose
+snaffle GET https://httpbin.org/get --verbose
 
 # 4. GET request with a custom header (e.g., Authorization token):
-pyfetch GET https://httpbin.org/headers -H "Authorization: Bearer your_token_here"
+snaffle GET https://httpbin.org/headers -H "Authorization: Bearer your_token_here"
 
 # 5. POST request with JSON data and custom Content-Type header:
-pyfetch POST https://httpbin.org/post -d '{"key": "value"}' -H "Content-Type: application/json"
+snaffle POST https://httpbin.org/post -d '{"key": "value"}' -H "Content-Type: application/json"
 
 # 6. PUT request example to update a resource:
-pyfetch PUT https://httpbin.org/put -d '{"name": "New Name"}' -H "Content-Type: application/json"
+snaffle PUT https://httpbin.org/put -d '{"name": "New Name"}' -H "Content-Type: application/json"
 
 # 7. PATCH request example to partially update a resource:
-pyfetch PATCH https://httpbin.org/patch -d '{"email": "user@example.com"}' -H "Content-Type: application/json"
+snaffle PATCH https://httpbin.org/patch -d '{"email": "user@example.com"}' -H "Content-Type: application/json"
 
 # 8. DELETE request to remove a resource:
-pyfetch DELETE https://httpbin.org/delete
+snaffle DELETE https://httpbin.org/delete
 
 # 9. HEAD request to fetch only headers:
-pyfetch HEAD https://httpbin.org/get
+snaffle HEAD https://httpbin.org/get
 
 # 10. OPTIONS request to check allowed methods:
-pyfetch OPTIONS https://httpbin.org/get
+snaffle OPTIONS https://httpbin.org/get
 
 # 11. Show help message:
-pyfetch HELP
+snaffle HELP
 ```
 
 ## Testing
@@ -299,7 +314,7 @@ To add new tests:
 ### GET Request
 
 ```
-usage: pyfetch GET [-h] [-t TIMEOUT] [-H HEADER] [-v] [--progress] url
+usage: snaffle GET [-h] [-t TIMEOUT] [-H HEADER] [-v] [--progress] url
 
 positional arguments:
   url                   Target URL
@@ -317,7 +332,7 @@ options:
 ### POST Request
 
 ```
-usage: pyfetch POST [-h] [-t TIMEOUT] [-d DATA] url
+usage: snaffle POST [-h] [-t TIMEOUT] [-d DATA] url
 
 positional arguments:
   url                   Target URL
@@ -332,7 +347,7 @@ options:
 ### PUT Request
 
 ```
-usage: pyfetch PUT [-h] [-t TIMEOUT] [-d DATA] url
+usage: snaffle PUT [-h] [-t TIMEOUT] [-d DATA] url
 
 positional arguments:
   url                   Target URL
@@ -347,7 +362,7 @@ options:
 ### PATCH Request
 
 ```
-usage: pyfetch PATCH [-h] [-t TIMEOUT] [-d DATA] url
+usage: snaffle PATCH [-h] [-t TIMEOUT] [-d DATA] url
 
 positional arguments:
   url                   Target URL
@@ -362,7 +377,7 @@ options:
 ### DELETE Request
 
 ```
-usage: pyfetch DELETE [-h] [-t TIMEOUT] url
+usage: snaffle DELETE [-h] [-t TIMEOUT] url
 
 positional arguments:
   url                   Target URL
@@ -376,7 +391,7 @@ options:
 ### HEAD Request
 
 ```
-usage: pyfetch HEAD [-h] [-t TIMEOUT] url
+usage: snaffle HEAD [-h] [-t TIMEOUT] url
 
 positional arguments:
   url                   Target URL
@@ -390,7 +405,7 @@ options:
 ### OPTIONS Request
 
 ```
-usage: pyfetch OPTIONS [-h] [-t TIMEOUT] url
+usage: snaffle OPTIONS [-h] [-t TIMEOUT] url
 
 positional arguments:
   url                   Target URL
@@ -446,7 +461,7 @@ All errors are displayed with descriptive messages to help diagnose the issue.
 1. Command not found:
 
 - Run `uv sync --group dev` to install the project and its tooling
-- Use `uv run pyfetch HELP` to invoke the CLI inside the managed environment
+- Use `uv run snaffle HELP` to invoke the CLI inside the managed environment
 
 2. Import errors:
 

--- a/README.md
+++ b/README.md
@@ -138,25 +138,6 @@ tests/              One module per source module: test_<module>.py
 The package is fully typed and ships a `py.typed` marker, so downstream type
 checkers use its annotations without extra configuration.
 
-## Upgrading from PyFetch
-
-This project was called PyFetch through 2.x. In 3.0.0 the package, the
-distribution, and the command all became `snaffle`:
-
-```python
-from pyfetch import HTTPClient   # 2.x
-from snaffle import HTTPClient   # 3.0+
-```
-
-```bash
-pyfetch GET https://example.com   # 2.x
-snaffle GET https://example.com   # 3.0+
-```
-
-There is no compatibility shim. Earlier still, 2.0.0 renamed the import package
-from `PyFetch` to `pyfetch` for PEP 8. See [CHANGELOG.md](CHANGELOG.md) for the
-full history.
-
 ## Library Usage
 
 You can also use Snaffle as a library in your Python projects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pyfetch"
-version = "2.0.0"
+name = "snaffle"
+version = "3.0.0"
 description = "A simple HTTP CLI client"
 readme = "README.md"
 license = "Apache-2.0"
@@ -29,16 +29,16 @@ speedups = ["zstandard>=0.23", "brotli>=1.1"]
 
 [project.scripts]
 # Points at `run`, not `cli:main`, so the console script gets the same
-# KeyboardInterrupt handling as `python -m pyfetch`.
-pyfetch = "pyfetch.__main__:run"
+# KeyboardInterrupt handling as `python -m snaffle`.
+snaffle = "snaffle.__main__:run"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["pyfetch", "pyfetch.*"]
+include = ["snaffle", "snaffle.*"]
 
 [tool.setuptools.package-data]
 # PEP 561: ship the marker so downstream type checkers use our annotations.
-pyfetch = ["py.typed"]
+snaffle = ["py.typed"]
 
 [dependency-groups]
 dev = ["mypy>=1.13,<2", "ruff>=0.11.5,<0.12", "types-requests>=2.33.0,<3"]
@@ -49,7 +49,7 @@ strict = true
 files = ["src", "tests"]
 mypy_path = "src"
 # Build output duplicates the package; without this, `mypy .` after a build
-# fails with "Duplicate module named 'pyfetch'".
+# fails with "Duplicate module named 'snaffle'".
 exclude = ["^build/", "^dist/"]
 
 [[tool.mypy.overrides]]
@@ -66,7 +66,7 @@ select = ["E", "F", "W", "I", "UP", "B", "C4", "SIM", "RUF", "PERF"]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["pyfetch"]
+known-first-party = ["snaffle"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/snaffle/__init__.py
+++ b/src/snaffle/__init__.py
@@ -6,7 +6,7 @@ command-line tool and as a library in other Python applications.
 
 `HTTPClient` is resolved lazily (PEP 562) so that importing this package -- or
 running the CLI's help paths -- does not pull in `requests`, which costs well
-over 100 ms of interpreter start-up on its own. `from pyfetch import HTTPClient`
+over 100 ms of interpreter start-up on its own. `from snaffle import HTTPClient`
 keeps working exactly as before and imports the stack on first access.
 
 Public API:
@@ -18,12 +18,12 @@ Public API:
 
 from typing import TYPE_CHECKING, Any
 
-from pyfetch.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
+from snaffle.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
 
 if TYPE_CHECKING:
-    from pyfetch.http_client import HTTPClient
+    from snaffle.http_client import HTTPClient
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 __all__ = [
     "HTTPClient",
@@ -37,7 +37,7 @@ __all__ = [
 def __getattr__(name: str) -> Any:
     """Resolves `HTTPClient` on first access, deferring the `requests` import."""
     if name == "HTTPClient":
-        from pyfetch.http_client import HTTPClient
+        from snaffle.http_client import HTTPClient
 
         return HTTPClient
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/snaffle/__main__.py
+++ b/src/snaffle/__main__.py
@@ -1,13 +1,13 @@
-"""Main entry point for the pyfetch command-line application.
+"""Main entry point for the snaffle command-line application.
 
-This module allows the pyfetch application to be executed as a package
-by running `python -m pyfetch`. It handles the initial execution and
+This module allows the snaffle application to be executed as a package
+by running `python -m snaffle`. It handles the initial execution and
 catches common exceptions like `KeyboardInterrupt`.
 """
 
 import sys
 
-from pyfetch.cli import main
+from snaffle.cli import main
 
 
 def run() -> None:

--- a/src/snaffle/cli.py
+++ b/src/snaffle/cli.py
@@ -1,7 +1,7 @@
 """Command-line interface for making HTTP requests.
 
 This module provides a command-line interface (CLI) for making HTTP requests
-using the pyfetch HTTP client. It supports common HTTP methods, custom headers,
+using the snaffle HTTP client. It supports common HTTP methods, custom headers,
 JSON data, and other features.
 
 The HTTP client (and with it ``requests``) is imported lazily so that ``--help``,
@@ -17,7 +17,7 @@ import textwrap
 from collections.abc import Sequence
 from typing import Any, NamedTuple, TypedDict
 
-from pyfetch.exceptions import HTTPClientError
+from snaffle.exceptions import HTTPClientError
 
 
 class RequestKwargs(TypedDict, total=False):
@@ -31,37 +31,37 @@ EXAMPLES = textwrap.dedent(
     """
      Examples:
           1. Normal GET request:
-              pyfetch GET https://httpbin.org/get
+              snaffle GET https://httpbin.org/get
 
           2. GET request with progress bar (for files larger than 5MB):
-              pyfetch GET https://example.com/large-file.zip --progress
+              snaffle GET https://example.com/large-file.zip --progress
 
           3. GET request with verbose mode to see retry logs and detailed output:
-              pyfetch GET https://httpbin.org/get --verbose
+              snaffle GET https://httpbin.org/get --verbose
 
           4. GET request with a custom header (e.g., Authorization token):
-              pyfetch GET https://httpbin.org/headers -H "Authorization: Bearer your_token_here"
+              snaffle GET https://httpbin.org/headers -H "Authorization: Bearer your_token_here"
 
           5. POST request with JSON data and custom Content-Type header:
-              pyfetch POST https://httpbin.org/post -d '{"key": "value"}' -H "Content-Type: application/json"
+              snaffle POST https://httpbin.org/post -d '{"key": "value"}' -H "Content-Type: application/json"
 
           6. PUT request example to update a resource:
-              pyfetch PUT https://httpbin.org/put -d '{"name": "New Name"}' -H "Content-Type: application/json"
+              snaffle PUT https://httpbin.org/put -d '{"name": "New Name"}' -H "Content-Type: application/json"
 
           7. PATCH request example to partially update a resource:
-              pyfetch PATCH https://httpbin.org/patch -d '{"email": "user@example.com"}' -H "Content-Type: application/json"
+              snaffle PATCH https://httpbin.org/patch -d '{"email": "user@example.com"}' -H "Content-Type: application/json"
 
           8. DELETE request to remove a resource:
-              pyfetch DELETE https://httpbin.org/delete
+              snaffle DELETE https://httpbin.org/delete
 
           9. HEAD request to fetch only headers:
-              pyfetch HEAD https://httpbin.org/get
+              snaffle HEAD https://httpbin.org/get
 
           10. OPTIONS request to check allowed methods:
-              pyfetch OPTIONS https://httpbin.org/get
+              snaffle OPTIONS https://httpbin.org/get
 
           11. Show help message:
-              pyfetch HELP
+              snaffle HELP
      """
 )
 
@@ -87,7 +87,7 @@ COMMANDS: tuple[Command, ...] = (
 
 
 def show_examples(suppress_output: bool = False) -> str:
-    """Prints usage examples for the pyfetch CLI.
+    """Prints usage examples for the snaffle CLI.
 
     This function displays a list of common commands to guide the user.
 
@@ -205,9 +205,9 @@ def create_parser() -> argparse.ArgumentParser:
         argparse.ArgumentParser: The configured argument parser.
     """
     parser = argparse.ArgumentParser(
-        # Pinned so `pyfetch`, `python -m pyfetch`, and a direct script call all
+        # Pinned so `snaffle`, `python -m snaffle`, and a direct script call all
         # print the same usage line instead of echoing the interpreter path.
-        prog="pyfetch",
+        prog="snaffle",
         description="HTTP CLI client supporting GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS methods",
         formatter_class=CustomFormatter,
         add_help=True,
@@ -244,7 +244,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None, suppress_output: bool = False) -> None:
-    """The main entry point for the pyfetch CLI.
+    """The main entry point for the snaffle CLI.
 
     This function parses command-line arguments, initializes the HTTP client,
     and executes the requested HTTP command. It also handles response printing
@@ -268,7 +268,7 @@ def main(argv: Sequence[str] | None = None, suppress_output: bool = False) -> No
         return
 
     # Deferred so the help paths above never import the HTTP stack.
-    from pyfetch.http_client import HTTPClient
+    from snaffle.http_client import HTTPClient
 
     try:
         kwargs = _parse_request_kwargs(args)

--- a/src/snaffle/exceptions.py
+++ b/src/snaffle/exceptions.py
@@ -1,12 +1,12 @@
-"""Custom exceptions for the pyfetch HTTP client.
+"""Custom exceptions for the snaffle HTTP client.
 
 This module defines a hierarchy of custom exceptions to provide more specific
-error information when using the pyfetch client.
+error information when using the snaffle client.
 """
 
 
 class HTTPClientError(Exception):
-    """Base exception for all errors raised by the pyfetch client.
+    """Base exception for all errors raised by the snaffle client.
 
     This exception serves as the base for more specific client-related errors,
     allowing for consolidated error handling.

--- a/src/snaffle/http_client.py
+++ b/src/snaffle/http_client.py
@@ -18,7 +18,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from pyfetch.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
+from snaffle.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
 
 
 class ProgressBar(Protocol):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from pyfetch.cli import main, show_examples
+from snaffle.cli import main, show_examples
 
 
 class TestCLI(unittest.TestCase):
@@ -39,7 +39,7 @@ class TestCLI(unittest.TestCase):
             main(["HELP"], suppress_output=True)
             self.assertEqual("", fake_stdout.getvalue())
 
-    @patch("pyfetch.http_client.HTTPClient.get")
+    @patch("snaffle.http_client.HTTPClient.get")
     def test_get_command(self, mock_get: MagicMock) -> None:
         """Test the GET command."""
         mock_get.return_value = self._build_response(text="Success")
@@ -53,7 +53,7 @@ class TestCLI(unittest.TestCase):
         self.assertIn("Response Body:", output)
         self.assertIn("Success", output)
 
-    @patch("pyfetch.http_client.HTTPClient.post")
+    @patch("snaffle.http_client.HTTPClient.post")
     def test_post_command(self, mock_post: MagicMock) -> None:
         """Test the POST command."""
         mock_post.return_value = self._build_response(
@@ -73,7 +73,7 @@ class TestCLI(unittest.TestCase):
             json={"key": "value"},
         )
 
-    @patch("pyfetch.http_client.HTTPClient.post")
+    @patch("snaffle.http_client.HTTPClient.post")
     def test_progress_is_not_available_for_post(self, mock_post: MagicMock) -> None:
         """Test that --progress is not available for POST command."""
         mock_post.return_value.text = "{}"
@@ -99,7 +99,7 @@ class TestCLI(unittest.TestCase):
 
         self.assertIn("Invalid JSON data", fake_stdout.getvalue())
 
-    @patch("pyfetch.http_client.HTTPClient.get")
+    @patch("snaffle.http_client.HTTPClient.get")
     def test_suppress_output_hides_response_text(self, mock_get: MagicMock) -> None:
         """Test suppress_output keeps stdout clean during command execution."""
         mock_get.return_value = self._build_response(text="Success")
@@ -111,14 +111,14 @@ class TestCLI(unittest.TestCase):
 
     def test_usage_line_is_stable_across_entry_points(self) -> None:
         """Test help output names the command, not whatever launched it."""
-        from pyfetch.cli import create_parser
+        from snaffle.cli import create_parser
 
-        self.assertTrue(create_parser().format_usage().startswith("usage: pyfetch"))
+        self.assertTrue(create_parser().format_usage().startswith("usage: snaffle"))
 
     def test_help_path_does_not_import_requests(self) -> None:
         """Guard the start-up win: help must not drag in the HTTP stack."""
         probe = (
-            "import sys; from pyfetch.cli import main; main(['HELP'], True);"
+            "import sys; from snaffle.cli import main; main(['HELP'], True);"
             " sys.exit(1 if 'requests' in sys.modules else 0)"
         )
         result = subprocess.run(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unittest
 
-from pyfetch.exceptions import HTTPClientError
+from snaffle.exceptions import HTTPClientError
 
 
 class TestHTTPClientError(unittest.TestCase):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -15,8 +15,8 @@ import requests
 from urllib3.exceptions import ConnectTimeoutError, ReadTimeoutError
 from urllib3.util.retry import Retry
 
-from pyfetch.exceptions import HTTPConnectionError, ResponseError
-from pyfetch.http_client import HTTPClient
+from snaffle.exceptions import HTTPConnectionError, ResponseError
+from snaffle.http_client import HTTPClient
 
 SESSION_REQUEST = "requests.Session.request"
 

--- a/uv.lock
+++ b/uv.lock
@@ -354,46 +354,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyfetch"
-version = "2.0.0"
-source = { editable = "." }
-dependencies = [
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "urllib3" },
-]
-
-[package.optional-dependencies]
-speedups = [
-    { name = "brotli" },
-    { name = "zstandard" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "ruff" },
-    { name = "types-requests" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "brotli", marker = "extra == 'speedups'", specifier = ">=1.1" },
-    { name = "requests", specifier = ">=2.33.1" },
-    { name = "tqdm", specifier = ">=4.66.0" },
-    { name = "urllib3", specifier = ">=2.7.0" },
-    { name = "zstandard", marker = "extra == 'speedups'", specifier = ">=0.23" },
-]
-provides-extras = ["speedups"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy", specifier = ">=1.13,<2" },
-    { name = "ruff", specifier = ">=0.11.5,<0.12" },
-    { name = "types-requests", specifier = ">=2.33.0,<3" },
-]
-
-[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -431,6 +391,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/91/263e33ab93ab09ca06ce4f8f8547a858cc198072f873ebc9be7466790bae/ruff-0.11.13-py3-none-win32.whl", hash = "sha256:96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250", size = 10474944, upload-time = "2025-06-05T21:00:08.459Z" },
     { url = "https://files.pythonhosted.org/packages/46/f4/7c27734ac2073aae8efb0119cae6931b6fb48017adf048fdf85c19337afc/ruff-0.11.13-py3-none-win_amd64.whl", hash = "sha256:29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3", size = 11548669, upload-time = "2025-06-05T21:00:11.147Z" },
     { url = "https://files.pythonhosted.org/packages/ec/bf/b273dd11673fed8a6bd46032c0ea2a04b2ac9bfa9c628756a5856ba113b0/ruff-0.11.13-py3-none-win_arm64.whl", hash = "sha256:b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b", size = 10683928, upload-time = "2025-06-05T21:00:13.758Z" },
+]
+
+[[package]]
+name = "snaffle"
+version = "3.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "urllib3" },
+]
+
+[package.optional-dependencies]
+speedups = [
+    { name = "brotli" },
+    { name = "zstandard" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+    { name = "types-requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "brotli", marker = "extra == 'speedups'", specifier = ">=1.1" },
+    { name = "requests", specifier = ">=2.33.1" },
+    { name = "tqdm", specifier = ">=4.66.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+    { name = "zstandard", marker = "extra == 'speedups'", specifier = ">=0.23" },
+]
+provides-extras = ["speedups"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.13,<2" },
+    { name = "ruff", specifier = ">=0.11.5,<0.12" },
+    { name = "types-requests", specifier = ">=2.33.0,<3" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why rename

Two concrete problems with the old name, both found by checking rather than assuming:

1. **It was taken on PyPI**, by an unrelated *"Python system information tool"*. This project could never have published under it.
2. **It pointed at the wrong category.** `*fetch` names — `neofetch`, `screenfetch` and friends — denote system-info reporters. Anyone hearing it expected an ASCII distro logo, not an HTTP client.

> **snaffle** *(verb, informal, British)* — to take something for oneself, typically quickly or without permission.
>
> *"Snaffle it off the server."*

Confirmed available on PyPI, a valid Python identifier, and it reads as a verb on the command line. Shortlisted against ~150 candidates checked live against the PyPI API; `snarf` — the Jargon File term for grabbing a file over a network, and the best conceptual fit — was already taken, as were `yoink`, `whippet`, `badger`, `ferret`, `magpie`, `poke` and `knock`.

## Breaking change

The import package, the distribution, and the console script are all `snaffle`. Bumped to **3.0.0**.

```python
from snaffle import HTTPClient
```

```bash
snaffle GET https://example.com
```

**No compatibility shim and no migration guidance** — none is being offered, so the upgrade notes and every reference to the previous name were removed rather than left as dead weight. `git grep` confirms zero mentions across all tracked files. The changelog keeps its version history but now describes what changed rather than what things used to be called.

## README

Added the dictionary definition as an epigraph, plus a one-line usage example under the intro.

## Testing

- ruff, `ruff format --check`, mypy strict all clean.
- 38 tests pass.
- 10-case end-to-end CLI smoke run passes.
- Both entry points render `usage: snaffle` — `snaffle HELP` and `python -m snaffle HELP`.
- Wheel builds as `snaffle-3.0.0-py3-none-any.whl` and contains `snaffle/py.typed`; the CI check was updated to the new path.
- Git recorded all six files as renames, so history follows.

## Follow-up after merge

The GitHub repository should be renamed to `maltemindedal/snaffle` (GitHub redirects the old URL). The README and changelog already point at the new one. The local working directory can be renamed whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
