### PR TITLE
Fix the help-text leak and correct the documented error mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `-d`/`--data` help text no longer prints a literal `R|` prefix:
+  `-d, --data DATA  R|JSON data for request body.` The marker belonged to a
+  custom help formatter that was only ever attached to the top-level parser,
+  never to the subcommands carrying the marker, so it leaked into the output it
+  was meant to control. Both the formatter and the marker are gone.
+- Corrected the documented exception mapping, which was wrong in two places.
+  Retries exhausted against a server that kept returning a transient status
+  raise `ResponseError` carrying the real status, not `HTTPConnectionError` —
+  the adapter is built with `raise_on_status=False`, so the last response is
+  reported rather than discarded. And a connect timeout raises
+  `HTTPConnectionError`, not `HTTPClientError`, because
+  `requests.exceptions.ConnectTimeout` subclasses `ConnectionError`. Only read
+  timeouts reach `HTTPClientError`. Behaviour is unchanged; the documentation
+  now matches it.
+- `HTTPClient.allowed_methods` is now the attribute method validation actually
+  reads. It was assigned in `__init__` and documented, but every request
+  checked the `ALLOWED_METHODS` class constant instead, so the instance
+  attribute did nothing.
+
 ### Changed
 
 - Relicensed from Apache-2.0 to MIT. The `license` field in `pyproject.toml`
   and the `LICENSE` file both carry the new terms; releases up to and including
   3.0.0 remain available under Apache-2.0.
+- `snaffle.__version__` is read from the installed distribution's metadata
+  instead of being hard-coded, so the version is declared once, in
+  `pyproject.toml`. It resolves lazily through the same PEP 562 hook as
+  `HTTPClient`, so `import snaffle` does not pay for the lookup. The value is
+  unchanged.
+- The CLI dispatches through `HTTPClient.make_request(method, url)` rather than
+  looking the per-verb method up by name with `getattr`.
 
 ### Added
 
@@ -19,6 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference, and the architecture, including decision records for the retry
   policy, the lazy imports, and the src-layout move. `README.md` is now a front
   door that links into it.
+- Test modules for `__init__.py` and `__main__.py`, the two source modules that
+  had none. These cover the `Ctrl+C`-exits-`0` contract of the console script,
+  the lazy resolution of `HTTPClient` and `__version__`, and a subprocess guard
+  that `import snaffle` does not pull in `requests`.
+
+### Removed
+
+- `snaffle.cli.show_examples` and the `suppress_output` parameter of
+  `snaffle.cli.main`. Neither was part of the documented public API — that is
+  `HTTPClient` and the three exceptions — and the flag existed only to quiet
+  tests that already redirect stdout.
 
 ## [3.0.0] - 2026-07-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,20 +10,28 @@ the way it is.
 ```
 src/snaffle/        The package. src-layout, so tests run against the
                     installed distribution rather than the working directory.
-  __init__.py       Public API. Resolves HTTPClient lazily (PEP 562).
+  __init__.py       Public API. Resolves HTTPClient and __version__ lazily
+                    (PEP 562).
   __main__.py       `python -m snaffle` and the `snaffle` console script.
   cli.py            Argument parsing and response rendering.
   http_client.py    The HTTP client, session pooling, and retry policy.
   exceptions.py     Exception hierarchy.
   py.typed          PEP 561 marker.
 tests/              One test module per source module: test_<module>.py.
+                    Dunder modules drop the underscores, so `__init__.py` is
+                    covered by `test_init.py` and `__main__.py` by
+                    `test_main.py`.
 ```
 
 Conventions:
 
 - Package and module names are short and all-lowercase (PEP 8). The import
   package is `snaffle`; there is no `Snaffle`.
-- Every public module, class, and function carries a docstring.
+- Every public module, class, and function carries a docstring — including
+  dunder methods such as `__enter__` and `__exit__`.
+- The version is declared once, in `pyproject.toml`. `snaffle.__version__`
+  reads it back from the installed distribution's metadata; do not hard-code
+  it in a second place.
 - Imports of first-party code are absolute (`from snaffle.exceptions import ...`),
   never relative.
 - Anything that would import `requests` at module scope should be deferred, so

--- a/docs/architecture/decisions/0002-lazy-imports-on-the-cli-help-path.md
+++ b/docs/architecture/decisions/0002-lazy-imports-on-the-cli-help-path.md
@@ -31,6 +31,11 @@ dependencies, so it is free.
 **`HTTPClient._create_progress_bar` imports `tqdm` inside the function.** A run
 without `--progress` never pays for it.
 
+**The same `__getattr__` resolves `__version__` from `importlib.metadata`.**
+Added later, when the hand-maintained `__version__` string was replaced by a
+read of the installed distribution's metadata. Deferring it keeps that read off
+every `import snaffle`, where nothing needs it.
+
 ## Consequences
 
 CLI start-up for `snaffle HELP` fell from 238 ms to 80 ms.
@@ -44,16 +49,22 @@ import path silently undoes it, and nothing about the code makes that obvious.
 Two things guard against it:
 
 - `tests/test_cli.py::test_help_path_does_not_import_requests` spawns a
-  subprocess, runs `main(['HELP'], True)`, and fails if `requests` is in
+  subprocess, runs `main(['HELP'])`, and fails if `requests` is in
   `sys.modules` afterwards.
+- `tests/test_init.py::test_import_does_not_pull_in_requests` does the same for
+  a bare `import snaffle`, covering library users rather than the CLI.
 - `CONTRIBUTING.md` states the convention: anything that would import
   `requests` at module scope should be deferred.
 
-Static analysis sees less. `__getattr__` returns `Any`, so `HTTPClient` is
-typed for consumers only via the `TYPE_CHECKING` import in `__init__.py`. That
-import exists solely to keep the annotation visible to type checkers.
+Static analysis sees less. `__getattr__` returns `Any`, so `HTTPClient` and
+`__version__` are typed for consumers only via the `TYPE_CHECKING` block in
+`__init__.py`. That block exists solely to keep the annotations visible to type
+checkers. `cli.py` uses the same device to annotate `_emit_response` with
+`requests.Response` without importing `requests` at run time — a
+`TYPE_CHECKING` import is not a violation of this ADR, because it never
+executes.
 
-Reading the code is marginally harder: three imports sit somewhere other than
+Reading the code is marginally harder: four imports sit somewhere other than
 the top of their file, each with a comment saying why.
 
 ## Alternatives considered

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -91,12 +91,17 @@ with HTTPClient() as client:
 
 ## `Error: Failed to connect to ...`
 
-DNS failure, a refused connection, an unreachable host — or retries exhausted
-against a server that kept returning a transient status. Check the URL, then
-run with `-v` to see exactly what was attempted.
+DNS failure, a refused connection, an unreachable host, or a timeout while the
+connection was still being established. Check the URL, then run with `-v` to
+see exactly what was attempted and which `requests` exception was behind it.
 
 A connection failure is retried for every method, including `POST`: a request
 that never reached the server cannot have been acted on twice.
+
+A server that kept returning a transient status until the retries ran out does
+*not* land here — that ends as `Error: HTTP error occurred: 503 ...`, because
+the last response is reported rather than discarded. See the
+[Python API reference](../reference/python-api.md#make_request).
 
 ## A request hangs, then fails
 

--- a/docs/guides/using-as-a-library.md
+++ b/docs/guides/using-as-a-library.md
@@ -60,13 +60,14 @@ with HTTPClient() as client:
     try:
         response = client.get("https://httpbin.org/status/500")
     except ResponseError as error:
-        # 4xx or 5xx. raise_for_status() fired.
+        # 4xx or 5xx. raise_for_status() fired. A transient status that was
+        # retried and never recovered arrives here too, carrying the real code.
         print(f"Server said no: {error}")
     except HTTPConnectionError as error:
-        # DNS failure, refused connection, or retries exhausted.
+        # DNS failure, refused connection, or a connect timeout.
         print(f"Could not reach it: {error}")
     except HTTPClientError as error:
-        # Anything else from requests, including timeouts.
+        # Anything else from requests -- a read timeout, too many redirects.
         print(f"Request failed: {error}")
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,7 +1,10 @@
 # CLI reference
 
 Every command, alias, and flag accepted by `snaffle`. Help text below is
-reproduced from the program's own `--help` output.
+reproduced from the program's own `--help` output, as rendered by the `argparse`
+in Python 3.13 and later. On 3.10 through 3.12 — both supported — argparse
+repeats the metavar after each short option, so `-t, --timeout TIMEOUT` appears
+as `-t TIMEOUT, --timeout TIMEOUT`. Nothing else differs.
 
 ## Invocation
 
@@ -53,7 +56,7 @@ Applied by `add_common_arguments` to all seven method subcommands.
 | `url` (positional) | string | required | Target URL. |
 | `-t`, `--timeout` | int | `30` | Request timeout in seconds. Passed to `requests` as the `timeout` argument. |
 | `-H`, `--header` | string | none | HTTP header in `Key: Value` format. Repeatable; each occurrence adds one header. A value without a `:` exits `1` with `Error: Invalid header format. Use 'Key: Value'.` |
-| `-v`, `--verbose` | flag | off | Log the outgoing request and the response status and headers to stdout, prefixed `[VERBOSE]`. |
+| `-v`, `--verbose` | flag | off | Log the outgoing request, the response status and headers, and the underlying `requests` exception behind any failure, to stdout, prefixed `[VERBOSE]`. |
 | `-h`, `--help` | flag | — | Print this subcommand's help and exit. |
 
 ### `-d`, `--data` — `POST`, `PUT`, `PATCH` only
@@ -120,7 +123,7 @@ options:
   -H, --header HEADER   HTTP header in 'Key: Value' format. Can be used
                         multiple times.
   -v, --verbose         Enable verbose logging for debugging.
-  -d, --data DATA       R|JSON data for request body. Example: '{"key":
+  -d, --data DATA       JSON data for request body. Example: '{"key":
                         "value"}'
 ```
 

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -8,7 +8,10 @@ annotations without extra configuration.
 from snaffle import HTTPClient, HTTPClientError, HTTPConnectionError, ResponseError
 ```
 
-`snaffle.__version__` holds the distribution version as a string.
+`snaffle.__version__` holds the distribution version as a string. It is read
+from the installed distribution's metadata rather than hard-coded, so the
+version is stated once, in `pyproject.toml`. Like `HTTPClient` it resolves on
+first access, so `import snaffle` does not pay for the metadata lookup.
 
 `HTTPClient` is resolved through a module-level `__getattr__` (PEP 562), so
 `import snaffle` does not import `requests`. The import happens on first
@@ -37,7 +40,7 @@ call `close()`.
 | --- | --- | --- | --- |
 | `timeout` | `int` | `30` | Seconds before a request times out. Must be `> 0`; `ValueError` otherwise. |
 | `retries` | `int` | `3` | Total attempts for a failed request, not retries after the first. Must be `> 0`; `ValueError` otherwise. Translated to `urllib3.util.retry.Retry(total=retries - 1)`. |
-| `verbose` | `bool` | `False` | Print the outgoing request, and the response status and headers, prefixed `[VERBOSE]`. |
+| `verbose` | `bool` | `False` | Print the outgoing request, the response status and headers, and the underlying `requests` exception behind any failure, each prefixed `[VERBOSE]`. |
 | `show_progress` | `bool` | `False` | Stream `GET` responses and draw a `tqdm` bar once `Content-Length` reaches `MIN_SIZE_FOR_PROGRESS`. |
 
 Validation runs in `__init__`, before any network access.
@@ -50,7 +53,7 @@ Validation runs in `__init__`, before any network access.
 | `retries` | `int` | As constructed. |
 | `verbose` | `bool` | As constructed. |
 | `show_progress` | `bool` | As constructed. |
-| `allowed_methods` | `frozenset[str]` | Copy of `ALLOWED_METHODS`. |
+| `allowed_methods` | `frozenset[str]` | The methods this instance accepts. Initialised from `ALLOWED_METHODS` and read on every request. |
 | `session` | `requests.Session` | The pooled session, with the retrying adapter mounted on `http://` and `https://`. |
 
 The class defines no `__slots__`: instances stay weak-referenceable and accept
@@ -113,10 +116,24 @@ Raises:
 
 | Exception | When |
 | --- | --- |
-| `ValueError` | `method` is not in `ALLOWED_METHODS`. Raised before any network access. |
-| `ResponseError` | The response carried a 4xx or 5xx status. |
-| `HTTPConnectionError` | The connection failed, or the adapter exhausted its retries. |
-| `HTTPClientError` | Any other `requests.RequestException`, including timeouts. |
+| `ValueError` | `method` is not in `allowed_methods`. Raised before any network access. |
+| `ResponseError` | The response carried a 4xx or 5xx status — including a retryable status that was still failing on the last attempt. |
+| `HTTPConnectionError` | The connection was refused, unresolvable, or timed out while being established, or the adapter exhausted its retries on a connection error. |
+| `HTTPClientError` | Any other `requests.RequestException` — a read timeout, too many redirects, a malformed URL. |
+
+Two boundaries are easy to get wrong:
+
+- **Exhausted status retries surface as `ResponseError`, not `HTTPConnectionError`.**
+  The adapter is built with `raise_on_status=False`, so when a `503` is still a
+  `503` on the final attempt urllib3 returns that response rather than raising.
+  `raise_for_status()` then turns it into a `ResponseError` carrying the real
+  status, which is more useful than a generic connection failure. Only
+  *connection* retries exhaust into `RetryError`, and that is what the
+  `HTTPConnectionError` row above refers to.
+- **A connect timeout is an `HTTPConnectionError`; a read timeout is an
+  `HTTPClientError`.** `requests.exceptions.ConnectTimeout` subclasses
+  `ConnectionError`, so it is caught as a connection failure — which is what it
+  is. `ReadTimeout` does not, so it falls through to the general case.
 
 #### `close`
 
@@ -149,7 +166,7 @@ Defined in `snaffle.exceptions` and re-exported from `snaffle`.
 ```
 Exception
 └── HTTPClientError          base for everything this package raises
-    ├── HTTPConnectionError  the connection failed or retries were exhausted
+    ├── HTTPConnectionError  the connection failed, timed out, or was refused
     └── ResponseError        the server answered with a 4xx or 5xx status
 ```
 
@@ -183,6 +200,12 @@ with `backoff_factor=0.3`, `respect_retry_after_header=True`, and
 | Any other status (404, 401, ...) | not retried | not retried |
 
 The rationale is in [ADR 0001](../architecture/decisions/0001-selective-retries-and-connection-pooling.md).
+
+`raise_on_status=False` decides what a caller sees when retries run out: a
+status that never recovered comes back as a response and becomes a
+`ResponseError`, while a connection that never succeeded raises `RetryError`
+inside the adapter and becomes an `HTTPConnectionError`. See
+[Raises](#make_request) above.
 
 Because retries happen inside the adapter, mocking `requests.Session.request`
 cannot observe them — see [contributing](../../CONTRIBUTING.md#testing-notes).

--- a/src/snaffle/__init__.py
+++ b/src/snaffle/__init__.py
@@ -9,11 +9,15 @@ running the CLI's help paths -- does not pull in `requests`, which costs well
 over 100 ms of interpreter start-up on its own. `from snaffle import HTTPClient`
 keeps working exactly as before and imports the stack on first access.
 
+`__version__` is resolved the same way, from the installed distribution's
+metadata, so the version is stated in exactly one place: `pyproject.toml`.
+
 Public API:
     - `HTTPClient`: The main client for making HTTP requests.
     - `HTTPClientError`: Base exception for client errors.
     - `HTTPConnectionError`: Exception for connection-related issues.
     - `ResponseError`: Exception for bad HTTP responses.
+    - `__version__`: The installed distribution version.
 """
 
 from typing import TYPE_CHECKING, Any
@@ -23,7 +27,8 @@ from snaffle.exceptions import HTTPClientError, HTTPConnectionError, ResponseErr
 if TYPE_CHECKING:
     from snaffle.http_client import HTTPClient
 
-__version__ = "3.0.0"
+    #: Resolved lazily at runtime; declared here so type checkers see a `str`.
+    __version__: str
 
 __all__ = [
     "HTTPClient",
@@ -35,9 +40,18 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:
-    """Resolves `HTTPClient` on first access, deferring the `requests` import."""
+    """Resolves `HTTPClient` and `__version__` on first access.
+
+    Both are deferred: `HTTPClient` so that `requests` is not imported, and
+    `__version__` so that reading the installed distribution's metadata is not
+    charged to every import of this package.
+    """
     if name == "HTTPClient":
         from snaffle.http_client import HTTPClient
 
         return HTTPClient
+    if name == "__version__":
+        from importlib.metadata import version
+
+        return version("snaffle")
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/snaffle/cli.py
+++ b/src/snaffle/cli.py
@@ -15,9 +15,13 @@ import json
 import sys
 import textwrap
 from collections.abc import Sequence
-from typing import Any, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict
 
 from snaffle.exceptions import HTTPClientError
+
+if TYPE_CHECKING:
+    # Type-only, so the help paths still avoid importing the HTTP stack.
+    import requests
 
 
 class RequestKwargs(TypedDict, total=False):
@@ -86,23 +90,6 @@ COMMANDS: tuple[Command, ...] = (
 )
 
 
-def show_examples(suppress_output: bool = False) -> str:
-    """Prints usage examples for the snaffle CLI.
-
-    This function displays a list of common commands to guide the user.
-
-    Args:
-        suppress_output (bool, optional): If True, the output is not printed
-            to the console. Defaults to False.
-
-    Returns:
-        str: A string containing the usage examples.
-    """
-    if not suppress_output:
-        print(EXAMPLES)
-    return EXAMPLES
-
-
 def _parse_headers(header_args: Sequence[str] | None) -> dict[str, str] | None:
     """Parses repeated header arguments into a dictionary."""
     if not header_args:
@@ -134,7 +121,7 @@ def _parse_request_kwargs(args: argparse.Namespace) -> RequestKwargs:
     return kwargs
 
 
-def _emit_response(response: Any) -> None:
+def _emit_response(response: requests.Response) -> None:
     """Prints a formatted HTTP response using a single buffered write."""
     parts = [f"Status Code: {response.status_code}\n", "\nHeaders:\n"]
     parts.extend(f"{key}: {value}\n" for key, value in response.headers.items())
@@ -182,19 +169,6 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-class CustomFormatter(argparse.HelpFormatter):
-    """Custom help formatter to support multi-line help messages.
-
-    This formatter allows help text to be split into multiple lines
-    by prefixing it with "R|".
-    """
-
-    def _split_lines(self, text: str, width: int) -> list[str]:
-        if text.startswith("R|"):
-            return text[2:].splitlines()
-        return super()._split_lines(text, width)
-
-
 def create_parser() -> argparse.ArgumentParser:
     """Creates and configures the argument parser for the CLI.
 
@@ -209,7 +183,6 @@ def create_parser() -> argparse.ArgumentParser:
         # print the same usage line instead of echoing the interpreter path.
         prog="snaffle",
         description="HTTP CLI client supporting GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS methods",
-        formatter_class=CustomFormatter,
         add_help=True,
     )
 
@@ -231,7 +204,7 @@ def create_parser() -> argparse.ArgumentParser:
             sub.add_argument(
                 "-d",
                 "--data",
-                help=f"R|JSON data for request body.\nExample: '{command.data_example}'",
+                help=f"JSON data for request body. Example: '{command.data_example}'",
             )
         if command.accepts_progress:
             sub.add_argument(
@@ -243,7 +216,7 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None, suppress_output: bool = False) -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     """The main entry point for the snaffle CLI.
 
     This function parses command-line arguments, initializes the HTTP client,
@@ -252,8 +225,6 @@ def main(argv: Sequence[str] | None = None, suppress_output: bool = False) -> No
 
     Args:
         argv (Sequence[str], optional): Arguments to parse. Defaults to ``sys.argv``.
-        suppress_output (bool, optional): If True, suppresses all output to the
-            console, which is useful for testing. Defaults to False.
     """
     parser = create_parser()
     args = parser.parse_args(argv)
@@ -261,10 +232,9 @@ def main(argv: Sequence[str] | None = None, suppress_output: bool = False) -> No
     command = args.command.upper() if args.command else None
 
     if not command or command == "HELP":
-        if not suppress_output:
-            parser.print_help()
-            print("\n")
-        show_examples(suppress_output)
+        parser.print_help()
+        print("\n")
+        print(EXAMPLES)
         return
 
     # Deferred so the help paths above never import the HTTP stack.
@@ -278,19 +248,14 @@ def main(argv: Sequence[str] | None = None, suppress_output: bool = False) -> No
             verbose=args.verbose,
             show_progress=getattr(args, "progress", False),
         ) as client:
-            response = getattr(client, command.lower())(args.url, **kwargs)
-
-            if not suppress_output:
-                _emit_response(response)
+            _emit_response(client.make_request(command, args.url, **kwargs))
 
     except json.JSONDecodeError:
-        if not suppress_output:
-            print("Error: Invalid JSON data")
-            print("Make sure your JSON data is properly formatted.")
-            print('Example: \'{"key": "value"}\'')
+        print("Error: Invalid JSON data")
+        print("Make sure your JSON data is properly formatted.")
+        print('Example: \'{"key": "value"}\'')
         sys.exit(1)
     except (ValueError, HTTPClientError) as error:
         # json.JSONDecodeError is a ValueError, so it must be caught above this.
-        if not suppress_output:
-            print(f"Error: {error}")
+        print(f"Error: {error}")
         sys.exit(1)

--- a/src/snaffle/http_client.py
+++ b/src/snaffle/http_client.py
@@ -61,7 +61,8 @@ class HTTPClient:
         retries (int): The total number of attempts made for a failed request.
         verbose (bool): If True, enables detailed logging of requests and responses.
         show_progress (bool): If True, displays a progress bar for large downloads.
-        allowed_methods (frozenset): The supported HTTP methods.
+        allowed_methods (frozenset): The methods this instance accepts, read by
+            every request. Initialised from :attr:`ALLOWED_METHODS`.
         MIN_SIZE_FOR_PROGRESS (int): The minimum file size in bytes to trigger the progress bar.
     """
 
@@ -136,6 +137,7 @@ class HTTPClient:
         self.session.close()
 
     def __enter__(self) -> HTTPClient:
+        """Returns the client itself, for use as a context manager."""
         return self
 
     def __exit__(
@@ -144,13 +146,14 @@ class HTTPClient:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
+        """Closes the session on exit, suppressing nothing."""
         self.close()
 
     def _validate_method(self, method: str) -> str:
         """Normalizes and validates an HTTP method name."""
         normalized_method = method.upper()
-        if normalized_method not in self.ALLOWED_METHODS:
-            allowed_methods = ", ".join(sorted(self.ALLOWED_METHODS))
+        if normalized_method not in self.allowed_methods:
+            allowed_methods = ", ".join(sorted(self.allowed_methods))
             raise ValueError(
                 f"Unsupported HTTP method. Allowed methods: {allowed_methods}"
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,9 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from snaffle.cli import main, show_examples
+from snaffle.cli import EXAMPLES, main
+
+MAKE_REQUEST = "snaffle.http_client.HTTPClient.make_request"
 
 
 class TestCLI(unittest.TestCase):
@@ -28,21 +30,26 @@ class TestCLI(unittest.TestCase):
         )
 
     def test_help_command(self) -> None:
-        """Test the HELP command content."""
-        # Run help command with output suppressed
-        help_text = show_examples(suppress_output=True)
-        self.assertIn("Examples:", help_text)
-        self.assertIn("Normal GET request:", help_text)
-
-        # Verify main function with suppressed output
+        """Test the HELP command prints the usage examples."""
         with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
-            main(["HELP"], suppress_output=True)
-            self.assertEqual("", fake_stdout.getvalue())
+            main(["HELP"])
 
-    @patch("snaffle.http_client.HTTPClient.get")
-    def test_get_command(self, mock_get: MagicMock) -> None:
+        output = fake_stdout.getvalue()
+        self.assertIn("Examples:", output)
+        self.assertIn("Normal GET request:", output)
+        self.assertIn(EXAMPLES, output)
+
+    def test_no_command_prints_help(self) -> None:
+        """Test a bare invocation falls back to the same help path."""
+        with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
+            main([])
+
+        self.assertIn("Examples:", fake_stdout.getvalue())
+
+    @patch(MAKE_REQUEST)
+    def test_get_command(self, mock_request: MagicMock) -> None:
         """Test the GET command."""
-        mock_get.return_value = self._build_response(text="Success")
+        mock_request.return_value = self._build_response(text="Success")
 
         with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
             main(["GET", "https://api.example.com"])
@@ -52,11 +59,12 @@ class TestCLI(unittest.TestCase):
         self.assertIn("Headers:", output)
         self.assertIn("Response Body:", output)
         self.assertIn("Success", output)
+        mock_request.assert_called_once_with("GET", "https://api.example.com")
 
-    @patch("snaffle.http_client.HTTPClient.post")
-    def test_post_command(self, mock_post: MagicMock) -> None:
+    @patch(MAKE_REQUEST)
+    def test_post_command(self, mock_request: MagicMock) -> None:
         """Test the POST command."""
-        mock_post.return_value = self._build_response(
+        mock_request.return_value = self._build_response(
             status_code=201,
             text='{"created": true}',
             headers={"content-type": "application/json"},
@@ -68,15 +76,26 @@ class TestCLI(unittest.TestCase):
         output = fake_stdout.getvalue()
         self.assertIn("Status Code: 201", output)
         self.assertIn('"created": true', output)
-        mock_post.assert_called_once_with(
+        mock_request.assert_called_once_with(
+            "POST",
             "https://api.example.com",
             json={"key": "value"},
         )
 
-    @patch("snaffle.http_client.HTTPClient.post")
-    def test_progress_is_not_available_for_post(self, mock_post: MagicMock) -> None:
+    @patch(MAKE_REQUEST)
+    def test_lowercase_alias_sends_the_uppercase_method(
+        self, mock_request: MagicMock
+    ) -> None:
+        """Test `snaffle get` reaches the client as a normalized `GET`."""
+        mock_request.return_value = self._build_response(text="Success")
+
+        with patch("sys.stdout", new=io.StringIO()):
+            main(["get", "https://api.example.com"])
+
+        mock_request.assert_called_once_with("GET", "https://api.example.com")
+
+    def test_progress_is_not_available_for_post(self) -> None:
         """Test that --progress is not available for POST command."""
-        mock_post.return_value.text = "{}"
         with (
             self.assertRaises(SystemExit),
             patch("sys.stderr", new_callable=io.StringIO),
@@ -99,16 +118,6 @@ class TestCLI(unittest.TestCase):
 
         self.assertIn("Invalid JSON data", fake_stdout.getvalue())
 
-    @patch("snaffle.http_client.HTTPClient.get")
-    def test_suppress_output_hides_response_text(self, mock_get: MagicMock) -> None:
-        """Test suppress_output keeps stdout clean during command execution."""
-        mock_get.return_value = self._build_response(text="Success")
-
-        with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
-            main(["GET", "https://api.example.com"], suppress_output=True)
-
-        self.assertEqual("", fake_stdout.getvalue())
-
     def test_usage_line_is_stable_across_entry_points(self) -> None:
         """Test help output names the command, not whatever launched it."""
         from snaffle.cli import create_parser
@@ -117,8 +126,10 @@ class TestCLI(unittest.TestCase):
 
     def test_help_path_does_not_import_requests(self) -> None:
         """Guard the start-up win: help must not drag in the HTTP stack."""
+        # The help text lands in the subprocess's captured stdout; only the
+        # exit status matters here.
         probe = (
-            "import sys; from snaffle.cli import main; main(['HELP'], True);"
+            "import sys; from snaffle.cli import main; main(['HELP']);"
             " sys.exit(1 if 'requests' in sys.modules else 0)"
         )
         result = subprocess.run(

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -119,41 +119,43 @@ class TestHTTPClient(unittest.TestCase):
         mock_response.iter_content.assert_not_called()
         self.assertNotIn("stream", mock_request.call_args.kwargs)
 
-    @patch(SESSION_REQUEST)
-    def test_get_request_with_progress_large_file(
-        self, mock_request: MagicMock
-    ) -> None:
-        """Test GET request with progress for a large file."""
+    @staticmethod
+    def _get_with_progress(
+        mock_request: MagicMock, content_length: int
+    ) -> tuple[Any, MagicMock]:
+        """Runs a progress-enabled GET and reports whether a bar was drawn."""
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.headers = {"content-length": str(6 * 1024 * 1024)}  # 6MB file
+        mock_response.headers = {"content-length": str(content_length)}
         mock_response.iter_content.return_value = [b"data"] * 4
         mock_request.return_value = mock_response
 
         client = HTTPClient(show_progress=True)
-        with contextlib.redirect_stderr(io.StringIO()):  # silence the progress bar
+        with patch("tqdm.tqdm") as mock_tqdm:
             response = client.get("https://api.example.com")
-
-        self.assertEqual(response.status_code, 200)
-        mock_response.iter_content.assert_called_once()
+        return response, mock_tqdm
 
     @patch(SESSION_REQUEST)
-    def test_get_request_with_progress_small_file(
+    def test_progress_bar_is_drawn_above_the_threshold(
         self, mock_request: MagicMock
     ) -> None:
-        """Test GET request with progress enabled for a small file."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {"content-length": str(4 * 1024 * 1024)}  # 4MB file
-        mock_response.iter_content.return_value = [b"data"] * 4
-        mock_request.return_value = mock_response
-
-        client = HTTPClient(show_progress=True)
-        with contextlib.redirect_stderr(io.StringIO()):  # silence the progress bar
-            response = client.get("https://api.example.com")
+        """Test a 6MB download draws a bar: it is over MIN_SIZE_FOR_PROGRESS."""
+        response, mock_tqdm = self._get_with_progress(mock_request, 6 * 1024 * 1024)
 
         self.assertEqual(response.status_code, 200)
-        mock_response.iter_content.assert_called_once()
+        mock_tqdm.assert_called_once()
+
+    @patch(SESSION_REQUEST)
+    def test_progress_bar_is_suppressed_below_the_threshold(
+        self, mock_request: MagicMock
+    ) -> None:
+        """Test a 4MB download draws no bar, but still streams and buffers."""
+        response, mock_tqdm = self._get_with_progress(mock_request, 4 * 1024 * 1024)
+
+        self.assertEqual(response.status_code, 200)
+        mock_tqdm.assert_not_called()
+        # Streaming is driven by show_progress, not by the bar existing.
+        cast(Any, response).iter_content.assert_called_once()
 
     @patch(SESSION_REQUEST)
     def test_http_error_maps_to_response_error(self, mock_request: MagicMock) -> None:
@@ -167,22 +169,6 @@ class TestHTTPClient(unittest.TestCase):
         client = HTTPClient(retries=1)
         with self.assertRaises(ResponseError):
             client.get("https://api.example.com")
-
-    @patch(SESSION_REQUEST)
-    def test_non_retryable_status_is_attempted_once(
-        self, mock_request: MagicMock
-    ) -> None:
-        """Test a dead-end status is not re-sent; retrying a 404 only adds latency."""
-        mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            "404"
-        )
-        mock_request.return_value = mock_response
-
-        client = HTTPClient(retries=5)
-        with self.assertRaises(ResponseError):
-            client.get("https://api.example.com")
-        self.assertEqual(mock_request.call_count, 1)
 
     def test_unsupported_method_rejected(self) -> None:
         """Test an unsupported HTTP method raises before any network access."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,49 @@
+"""Test cases for the package's public surface and lazy attribute resolution."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from importlib.metadata import version
+
+import snaffle
+
+
+class TestPublicAPI(unittest.TestCase):
+    """Test cases for what `import snaffle` exposes."""
+
+    def test_every_name_in_all_resolves(self) -> None:
+        """Test `__all__` is honest: each entry is actually reachable."""
+        for name in snaffle.__all__:
+            with self.subTest(name=name):
+                self.assertIsNotNone(getattr(snaffle, name))
+
+    def test_http_client_resolves_lazily(self) -> None:
+        """Test the PEP 562 hook returns the real class."""
+        from snaffle.http_client import HTTPClient
+
+        self.assertIs(snaffle.HTTPClient, HTTPClient)
+
+    def test_version_comes_from_installed_metadata(self) -> None:
+        """Test `__version__` is not a second, hand-maintained copy."""
+        self.assertEqual(snaffle.__version__, version("snaffle"))
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        """Test the lazy hook still reports genuinely missing names."""
+        with self.assertRaises(AttributeError):
+            snaffle.does_not_exist  # noqa: B018
+
+    def test_import_does_not_pull_in_requests(self) -> None:
+        """Guard the start-up win at the package level, not just the CLI's."""
+        probe = "import sys, snaffle; sys.exit(1 if 'requests' in sys.modules else 0)"
+        result = subprocess.run(
+            [sys.executable, "-c", probe], capture_output=True, text=True
+        )
+        self.assertEqual(
+            result.returncode, 0, f"requests was imported by `import snaffle`: {result}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,48 @@
+"""Test cases for the package entry point."""
+
+from __future__ import annotations
+
+import io
+import unittest
+from unittest.mock import MagicMock, patch
+
+from snaffle.__main__ import run
+
+CLI_MAIN = "snaffle.__main__.main"
+
+
+class TestRun(unittest.TestCase):
+    """Test cases for `run`, the console script and `python -m` entry point."""
+
+    @patch(CLI_MAIN)
+    def test_run_delegates_to_the_cli(self, mock_main: MagicMock) -> None:
+        """Test the entry point calls the CLI and does not touch sys.exit."""
+        run()
+
+        mock_main.assert_called_once_with()
+
+    @patch(CLI_MAIN, side_effect=KeyboardInterrupt)
+    def test_keyboard_interrupt_exits_zero(self, _: MagicMock) -> None:
+        """Test Ctrl+C is a clean exit, not a traceback.
+
+        The console script points at `run` rather than `cli:main` precisely so
+        that it gets this handling; see the CLI reference on exit codes.
+        """
+        with (
+            patch("sys.stdout", new=io.StringIO()) as fake_stdout,
+            self.assertRaises(SystemExit) as caught,
+        ):
+            run()
+
+        self.assertEqual(caught.exception.code, 0)
+        self.assertIn("Operation cancelled by user", fake_stdout.getvalue())
+
+    @patch(CLI_MAIN, side_effect=ValueError("boom"))
+    def test_other_exceptions_are_not_swallowed(self, _: MagicMock) -> None:
+        """Test only KeyboardInterrupt is special-cased."""
+        with self.assertRaises(ValueError):
+            run()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A two-axis review of the codebase — against the repo's documented standards, and against its own documentation treated as the spec — turned up eighteen findings. This addresses all of them.

Behaviour changes are limited to the CLI help text. Everything else either makes the documentation match the code or removes machinery nothing used.

## Fixed

- **The `-d/--data` help printed a literal `R|` prefix.** The marker belonged to a custom formatter attached only to the top-level parser — never to the subcommands that actually carried the marker — so it leaked into the very output it was meant to control. Formatter and marker are both gone.
- **The documented exception mapping was wrong twice over.** Retries exhausted against a transient status raise `ResponseError` carrying the real status, not `HTTPConnectionError`: the adapter sets `raise_on_status=False`, so the last response is reported rather than discarded. And a connect timeout is an `HTTPConnectionError`, since `requests.exceptions.ConnectTimeout` subclasses `ConnectionError`; only read timeouts reach `HTTPClientError`. Corrected in the API reference and in both guides that repeated the claim.
- **`allowed_methods` did nothing.** It was assigned in `__init__` and documented as an instance attribute, but every request validated against the `ALLOWED_METHODS` class constant instead. It is now the attribute method validation reads.

## Changed

- `__version__` is read from the installed distribution's metadata instead of being a second hand-maintained copy of the version in `pyproject.toml`. It resolves through the existing PEP 562 hook, so `import snaffle` does not pay for the lookup; ADR 0002 records the new deferred import.
- The CLI dispatches through `make_request(method, url)` rather than looking the per-verb method up by name with `getattr`, which had erased the typed API. `_emit_response` is annotated `requests.Response` via a `TYPE_CHECKING` import, keeping the help path clear of the HTTP stack.

## Removed

- `cli.show_examples` and `main`'s `suppress_output` parameter. Neither is part of the documented public API — that is `HTTPClient` and the three exceptions — and the flag existed only to quiet tests that already redirect stdout. Filed under `Removed` in the changelog rather than as a breaking change for that reason; happy to keep the parameter if you'd rather.

## Tests

40 → 46.

- Dropped a retry test that mocked `requests.Session.request`. That mock sits above the adapter and cannot observe retries at all, so the assertion was vacuous — it would have passed with 404 in `RETRY_STATUSES`. This is exactly the trap `CONTRIBUTING.md` documents, and `TestRetryAgainstRealServer` already covers the case correctly.
- Split the duplicated large/small-file progress tests so each patches `tqdm` and asserts whether a bar was drawn. Both previously made the identical assertion, and the small-file case never checked the suppression it was named for.
- Added `tests/test_init.py` and `tests/test_main.py`, the two source modules that had no test module despite the one-per-source-module convention. They cover the `Ctrl+C`-exits-`0` contract of the console script, lazy resolution of `HTTPClient` and `__version__`, and a subprocess guard that a bare `import snaffle` does not pull in `requests`.

## Three judgement calls

Three findings were doc-vs-code conflicts. I fixed the docs, not the behaviour:

| Conflict | Why the code wins |
| --- | --- |
| Exhausted status retries | `raise_on_status=False` is a deliberate, separately documented choice, and a `ResponseError` carrying the real 503 tells the caller more than a generic connection failure. The existing real-socket test already asserted it. |
| Connect timeouts | A timeout while the connection is still being established *is* a connection failure. |
| `[VERBOSE]` error lines | Printing the underlying `requests` exception is what verbose mode is for. Documented rather than removed. |

Reversing any of these is a behavioural break, so flag it if you'd prefer the other direction.

## Verification

All four checks from `CONTRIBUTING.md` pass locally on 3.14:

```
uv run ruff check .            All checks passed!
uv run ruff format --check .   10 files already formatted
uv run mypy .                  Success: no issues found in 10 source files
uv run python -m unittest discover tests   Ran 46 tests — OK
```

Smoke-tested end to end against a live host: `GET` renders, a 404 exits `1` with the status in the message, `-v` prints the underlying exception, `python -m snaffle` prints help, and `snaffle.__version__` resolves to `3.0.0` from metadata — unchanged from the hard-coded value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
