### PR TITLE
Deepen four modules found by an architecture review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reads. It was assigned in `__init__` and documented, but every request
   checked the `ALLOWED_METHODS` class constant instead, so the instance
   attribute did nothing.
+- `stream=True` is no longer ignored when `show_progress` is on. A `GET` the
+  caller asked to stream now comes back unread, as the API reference, the
+  architecture overview and ADR 0001 all already claimed; previously the
+  progress bar drained the body anyway and the caller got nothing to iterate.
+  A caller who wants both a stream and a bar drives `tqdm` themselves, which is
+  what the large-download guide has always said.
+- The exit-code table in the CLI reference omitted a path: an argument value the
+  client rejects, such as `-t 0`, exits `1` through a `ValueError` from
+  `HTTPClient.__init__`. It is now listed, along with a non-integer `-t` under
+  code `2`. Behaviour is unchanged; the documentation now matches it.
 
 ### Changed
 
@@ -40,6 +50,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged.
 - The CLI dispatches through `HTTPClient.make_request(method, url)` rather than
   looking the per-verb method up by name with `getattr`.
+- The progress-bar download moved into a private `snaffle._download` module,
+  which owns the decision to drain, the size threshold, the deferred `tqdm`
+  import, the chunk loop, and the write-back onto the response.
+  `DOWNLOAD_CHUNK_SIZE` and `MIN_SIZE_FOR_PROGRESS` remain public attributes of
+  `HTTPClient`, and `ProgressBar` is still importable from
+  `snaffle.http_client`. The private `HTTPClient._stream_response` and
+  `HTTPClient._create_progress_bar` are gone.
+- `snaffle.cli.main` returns an exit code instead of calling `sys.exit`, and
+  `snaffle.__main__.run` is now the single process-level exit point, so the
+  error-to-code mapping is one visible thing in one module. `argparse` still
+  exits `2` from inside `parse_args`; that is a distinct mechanism and is
+  documented rather than routed through the return value. Observable behaviour
+  is unchanged — same messages, same codes, same stdout — but code that
+  embedded `cli.main` and caught `SystemExit` to detect an error must check the
+  return value instead.
+- The seven verb methods (`get`, `post`, `put`, `patch`, `delete`, `head`,
+  `options`) carry a one-line docstring pointing at `make_request` rather than
+  restating its arguments and return value seven times over. Signatures and
+  behaviour are unchanged; `help()` output is shorter.
 
 ### Added
 
@@ -51,6 +80,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   had none. These cover the `Ctrl+C`-exits-`0` contract of the console script,
   the lazy resolution of `HTTPClient` and `__version__`, and a subprocess guard
   that `import snaffle` does not pull in `requests`.
+- `HTTPClient` accepts a `session`, so the transport can be substituted at the
+  client's own interface instead of by patching `requests.Session.request`.
+  That patch point sits below the client and above the adapter, which is where
+  urllib3 retries, so it can never observe a retry — the project shipped a false
+  claim about `POST` retry behaviour on exactly that mistake. A session mounted
+  with a test adapter now observes retries with no socket opened. The parameter
+  is last and defaults to `None`, which builds the pooled, retrying session as
+  before; a session passed in is used as it arrives, so `retries` does not apply
+  to it, and the client closes only a session it built. See ADR 0004.
+- ADR 0004, recording the session seam. It supersedes only the mitigation in
+  ADR 0001's Consequences — documenting the mock trap — and not its decision.
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,19 @@ Type checking runs in `mypy --strict` over both `src/` and `tests/`.
 Do not mock `requests.Session.request` when the behaviour under test involves
 retries. That mock sits *above* the adapter where urllib3's retry logic lives,
 so it cannot observe retries at all — an earlier revision shipped a false claim
-about `POST` retry behaviour on exactly that mistake. Use
-`TestRetryAgainstRealServer`, which counts requests arriving at a real socket,
-or assert against `urllib3.util.retry.Retry` directly.
+about `POST` retry behaviour on exactly that mistake. Three ways to test retries
+without it:
+
+- Pass a session: `HTTPClient(session=...)` substitutes the transport at the
+  client's own interface rather than below it, so the adapter and its retry
+  loop stay in place. `TestRetryWithoutASocket` mounts an adapter over a pool
+  that fails every connection attempt and counts them, with no socket opened.
+- Count requests arriving at a real socket — `TestRetryAgainstRealServer`.
+- Assert against `urllib3.util.retry.Retry` directly — `TestRetryPolicy`.
+
+A session passed to the constructor is used as it arrives: `retries` does not
+apply to it, and the client does not close it. See
+[ADR 0004](docs/architecture/decisions/0004-inject-the-session.md).
 
 ## Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,15 @@ src/snaffle/        The package. src-layout, so tests run against the
   __main__.py       `python -m snaffle` and the `snaffle` console script.
   cli.py            Argument parsing and response rendering.
   http_client.py    The HTTP client, session pooling, and retry policy.
+  _download.py      Private. The progress-bar download: whether to drain a
+                    body, the size threshold, and the buffering.
   exceptions.py     Exception hierarchy.
   py.typed          PEP 561 marker.
 tests/              One test module per source module: test_<module>.py.
-                    Dunder modules drop the underscores, so `__init__.py` is
-                    covered by `test_init.py` and `__main__.py` by
-                    `test_main.py`.
+                    Dunder and private modules drop the underscores, so
+                    `__init__.py` is covered by `test_init.py`, `__main__.py`
+                    by `test_main.py`, and `_download.py` by
+                    `test_download.py`.
 ```
 
 Conventions:

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ way it is.
 | [0001 — Selective retries and a pooled session](architecture/decisions/0001-selective-retries-and-connection-pooling.md) | Why retries moved into the adapter, why only seven statuses are retried, why a `POST` is retried on connection failure but never replayed, and why a client must now be closed. |
 | [0002 — Lazy imports on the CLI help path](architecture/decisions/0002-lazy-imports-on-the-cli-help-path.md) | Why `requests` is imported in three unusual places, and what guards the saving. |
 | [0003 — src-layout and a lowercase package name](architecture/decisions/0003-src-layout-and-a-lowercase-package-name.md) | Why the package moved under `src/`, why it was renamed twice, and why both renames were major versions. |
+| [0004 — Inject the session](architecture/decisions/0004-inject-the-session.md) | Why the constructor accepts a session, why the client closes only the one it built, why `retries` does not reach an injected one, and what that costs the public interface. |
 
 ## Project documents
 

--- a/docs/architecture/decisions/0001-selective-retries-and-connection-pooling.md
+++ b/docs/architecture/decisions/0001-selective-retries-and-connection-pooling.md
@@ -68,6 +68,9 @@ against such a mock and shipped a false claim in the README on the strength of
 it. The project now tests retry behaviour against a real socket
 (`TestRetryAgainstRealServer`) or against the `Retry` object directly
 (`TestRetryPolicy`), and `CONTRIBUTING.md` records the trap.
+[ADR 0004](0004-inject-the-session.md) adds a third option — passing a session
+to the constructor — and supersedes this mitigation, though not the decision
+above.
 
 `--progress` downloads hold a larger working set, from the bigger chunk size.
 

--- a/docs/architecture/decisions/0002-lazy-imports-on-the-cli-help-path.md
+++ b/docs/architecture/decisions/0002-lazy-imports-on-the-cli-help-path.md
@@ -28,8 +28,10 @@ paths and argparse errors never reach it.
 access. The exceptions are imported eagerly — `exceptions.py` has no
 dependencies, so it is free.
 
-**`HTTPClient._create_progress_bar` imports `tqdm` inside the function.** A run
-without `--progress` never pays for it.
+**`snaffle._download` imports `tqdm` inside the function that builds the bar.**
+A run without `--progress` never pays for it. (This lived on
+`HTTPClient._create_progress_bar` until the progress-bar download moved into its
+own module; the deferral is unchanged, only its address.)
 
 **The same `__getattr__` resolves `__version__` from `importlib.metadata`.**
 Added later, when the hand-maintained `__version__` string was replaced by a

--- a/docs/architecture/decisions/0004-inject-the-session.md
+++ b/docs/architecture/decisions/0004-inject-the-session.md
@@ -1,0 +1,142 @@
+# 4. Inject the session
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+
+## Context
+
+[ADR 0001](0001-selective-retries-and-connection-pooling.md) moved retries into
+the session's `HTTPAdapter` and recorded the consequence: retries became
+invisible to the obvious mock. They run inside urllib3, below
+`requests.Session.request`, so patching that name cannot observe them. The
+project had already shipped a false claim on exactly that mistake — "a `POST`
+is never silently re-sent", asserted against such a mock, and wrong.
+
+The mitigation ADR 0001 chose was documentation: `CONTRIBUTING.md` names the
+trap, and the two ways around it are a real socket
+(`TestRetryAgainstRealServer`) or an assertion about the `Retry` object
+(`TestRetryPolicy`).
+
+That accepted the hazard as permanent, and the reason it looked permanent was a
+missing seam rather than anything about retries. `HTTPClient.__init__`
+constructed its own session — `self.session = self._build_session(retries)` —
+so the client declared no point at which its transport could be replaced.
+Substitution could only happen by patching, and the only name available to
+patch, `requests.Session.request`, sits in the gap between the client's
+interface and the adapter: below the thing being tested, above the thing that
+does the retrying. Eleven tests patch it. For the behaviour those eleven cover
+— method validation, exception translation, the progress delegation — it is the
+right tool. For retries it is a trap with a warning sign on it.
+
+## Decision
+
+**Accept a session instead of only constructing one.**
+
+```python
+def __init__(self, timeout=30, retries=3, verbose=False, show_progress=False,
+             session: requests.Session | None = None) -> None:
+```
+
+`_build_session(retries)` stays and remains the default, so the out-of-the-box
+client is unchanged. The parameter is last, so existing positional calls are
+unaffected.
+
+**A client closes only a session it built.** `__init__` records whether it
+built the session; `close()` — and therefore `__exit__` — is a no-op for one it
+was given. A caller may be sharing that session with other clients or with code
+that outlives this one, and closing it would pull the pool out from under them.
+
+**`retries` does not apply to a session that was passed in.** The retry policy
+and the connection pool both come from the session's mounted adapters, so they
+arrive with the session. `retries` builds the default session and nothing else.
+It remains validated and remains readable on `client.retries`.
+
+**Passing `retries` and `session` together is not an error.** The two are not
+contradictory: a caller who mounts a five-attempt adapter may reasonably want
+`client.retries` to report `5`, since that attribute is public and documented.
+The interaction is stated in the constructor docstring, in the API reference,
+and in `CONTRIBUTING.md` instead.
+
+**This supersedes the mitigation in ADR 0001's Consequences, not its decision.**
+Retries still live in the adapter; they are still invisible to a
+`requests.Session.request` mock; the method asymmetry is unchanged. What changes
+is that "test against a real socket or against the `Retry` object" is no longer
+the complete list of options.
+
+## Consequences
+
+Retry behaviour is observable at Snaffle's own interface without a socket.
+`TestRetryWithoutASocket` mounts a real `HTTPAdapter`, carrying the client's own
+`Retry`, over a pool whose every connection attempt fails before a socket is
+opened, and counts the attempts. It shows a `POST` being re-attempted three
+times on connection failure — the claim that was once asserted falsely — in
+about the time a mock takes.
+
+That test reaches into urllib3: the retry loop lives inside
+`HTTPConnectionPool.urlopen`, so the double has to sit under `urlopen`, and the
+lowest point above the socket is the private `_new_conn`. The coupling is
+narrower than it looks — one method, one exception type — but it is coupling to
+a private name, and it is recorded in the double's docstring.
+`TestRetryAgainstRealServer` stays, and remains the only test that exercises the
+whole stack.
+
+The eleven `@patch("requests.Session.request")` tests were left alone. The mock
+is still correct above the adapter, and rewriting them would have churned every
+test in the module for no change in what is covered. The trap they can fall
+into is unchanged, and so is the warning in `CONTRIBUTING.md`.
+
+**The public interface now names a `requests` type.** This is the real cost.
+[ADR 0002](0002-lazy-imports-on-the-cli-help-path.md) works to keep `requests`
+off the import path, and `HTTPClient.__init__` now has a parameter annotated
+`requests.Session | None`. There is no new start-up cost — `http_client.py`
+already imports `requests` at module scope, and `http_client` is itself imported
+lazily, which is what ADR 0002 actually protects; the guards in
+`tests/test_init.py` and `tests/test_cli.py` still pass unchanged. But the
+*interface* now mentions a third-party type on the way in, where before it did
+so only on the way out, as the `requests.Response` every request method returns. Snaffle is a thin layer over `requests` and has never
+hidden it, so this states something that was already true; it is still a
+widening of what the constructor commits to.
+
+Two rules now have to be documented rather than inferred: that a supplied
+session does not get `retries`, and that the client will not close it. Both are
+in the class docstring, the constructor docstring, the API reference, and
+`CONTRIBUTING.md`. A rule that lives only in the code is a rule that gets
+broken, and this one has a footgun on the other side of it.
+
+## Alternatives considered
+
+**Keep patch-only substitution.** The status quo, and it costs nothing to
+leave alone. It also leaves the seam in the one place where it cannot see the
+behaviour ADR 0001 exists for, and leaves `CONTRIBUTING.md` warning contributors
+away from the only substitution point the client offers. A warning is a weaker
+guarantee than a seam: it works exactly as long as everyone reads it, and this
+project has already shipped the failure it warns about.
+
+**Take a `Retry` or an `HTTPAdapter` instead of a session.** Narrower, and it
+looks like it dodges the ADR 0002 cost — but it does not, since both are also
+third-party types, and it dodges nothing else either. Adapters are mounted per
+scheme, so accepting one means deciding on the caller's behalf where it is
+mounted, and it still would not let a test replace the transport as a whole.
+
+**Take a callable instead — a `send` function or a protocol Snaffle defines.**
+Would keep `requests` out of the signature. It would also mean inventing an
+interface for a library that already has one, converting between it and
+`requests` at the boundary, and giving callers a seam that fits nothing they
+already own. Speculative abstraction to avoid naming a type the module already
+imports.
+
+**Raise `ValueError` when `retries` and `session` are passed together.** The
+case for it is that silently inert configuration is the same class of hazard
+this ADR closes. The case against won: `retries` has a real default, so the only
+implementable check compares the value against `3` and would let an explicit
+`retries=3` through while rejecting a legitimate `retries=5` that a caller
+passed to describe their own adapter. Detecting intent instead would mean a
+sentinel default, which changes the documented signature for a check nobody
+asked for. The interaction is documented and tested
+(`test_retries_do_not_reach_an_injected_session`) instead.
+
+**Close the injected session anyway**, so `close()` means one thing. Simpler to
+describe and worse to use: a shared session closed by whichever client finished
+first is a bug the caller cannot see coming, and it makes a client
+non-composable with any code that owns a session. The asymmetry is worth its two
+lines.

--- a/docs/architecture/decisions/0004-inject-the-session.md
+++ b/docs/architecture/decisions/0004-inject-the-session.md
@@ -93,9 +93,10 @@ already imports `requests` at module scope, and `http_client` is itself imported
 lazily, which is what ADR 0002 actually protects; the guards in
 `tests/test_init.py` and `tests/test_cli.py` still pass unchanged. But the
 *interface* now mentions a third-party type on the way in, where before it did
-so only on the way out, as the `requests.Response` every request method returns. Snaffle is a thin layer over `requests` and has never
-hidden it, so this states something that was already true; it is still a
-widening of what the constructor commits to.
+so only on the way out, as the `requests.Response` every request method returns.
+Snaffle is a thin layer over `requests` and has never hidden it, so this states
+something that was already true; it is still a widening of what the constructor
+commits to.
 
 Two rules now have to be documented rather than inferred: that a supplied
 session does not get `retries`, and that the client will not close it. Both are

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -34,10 +34,15 @@ artifact is a wheel.
 | `_download.py` | Private. Owns the progress-bar download whole: whether to drain, the size threshold, the deferred `tqdm` import, the chunk loop, and writing the buffer back onto the response. |
 | `exceptions.py` | Three exception classes. No dependencies, not even on `requests`. |
 
-The dependency graph is acyclic and shallow. `exceptions` depends on nothing;
-`_download` depends on the HTTP stack; `http_client` depends on `exceptions`,
-`_download`, and the HTTP stack; `cli` depends on `exceptions` at import time
-and on `http_client` at call time.
+The run-time dependency graph is acyclic and shallow. `exceptions` depends on
+nothing; `_download` depends on the HTTP stack; `http_client` depends on
+`exceptions`, `_download`, and the HTTP stack; `cli` depends on `exceptions` at
+import time and on `http_client` at call time.
+
+The one edge that runs the other way is type-only: `_download` refers to
+`http_client.ProgressBar` under `TYPE_CHECKING`, because the protocol is
+documented as part of `http_client`'s surface while the code that builds a bar
+lives in `_download`. Nothing is imported at run time, so the graph above holds.
 
 `_download` imports `requests` at module scope, as `http_client` does. That is
 safe because nothing reaches `_download` except through `http_client`, and

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -99,6 +99,14 @@ deliberate trade — it makes the common case (a batch of requests to one host)
 fast, at the price of requiring a context manager. See
 [ADR 0001](decisions/0001-selective-retries-and-connection-pooling.md).
 
+The client builds that session unless one is passed to the constructor, which is
+where the transport is substituted — including in tests, where it is the only
+seam above the socket that leaves the retry loop intact. A caller-supplied
+session brings its own adapters, so it brings its own retry policy and pool;
+`retries` does not reach it. Ownership follows construction: **a client closes
+only a session it built**, because one it was given may be shared. See
+[ADR 0004](decisions/0004-inject-the-session.md).
+
 ### Retries are selective, and asymmetric by method
 
 Only connection failures and the transient statuses in `RETRY_STATUSES` are
@@ -141,17 +149,23 @@ checkers use the annotations with no configuration.
 
 ## Testing strategy
 
-Tests are `unittest`, one module per source module. They split into three
+Tests are `unittest`, one module per source module. They split into four
 kinds, and the split is load-bearing:
 
 - **Mocked at `Session.request`** — most client and CLI tests. Fast, and
   correct for anything *above* the adapter.
 - **Asserted against `urllib3.util.retry.Retry` directly** — `TestRetryPolicy`.
   Verifies the policy object without any I/O.
+- **Injected at the session seam** — `TestInjectedSession` and
+  `TestRetryWithoutASocket` pass a session to the constructor. Because the
+  substitution happens at the client's interface rather than below it, the
+  adapter and urllib3's retry loop are still there: `TestRetryWithoutASocket`
+  mounts a real adapter over a pool that fails every connection attempt, and
+  counts them, without opening a socket.
 - **Against a real socket** — `TestRetryAgainstRealServer` starts a
-  `ThreadingHTTPServer` on an ephemeral port and counts arriving requests. This
-  is the only way to observe retries end to end. `TestProgressAgainstRealServer`
-  does the same for the streaming opt-out, which needs a real body to prove the
+  `ThreadingHTTPServer` on an ephemeral port and counts arriving requests. Its
+  subject is the whole stack, end to end. `TestProgressAgainstRealServer` does
+  the same for the streaming opt-out, which needs a real body to prove the
   socket is still unread.
 
 The class docstring on `TestRetryPolicy` records why: an earlier revision

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -4,7 +4,7 @@ Snaffle is a thin, opinionated layer over `requests` and `urllib3`. It exists to
 make two things convenient: a readable HTTP CLI, and a client whose retry and
 pooling behaviour is decided once rather than at every call site.
 
-It is deliberately small — five modules, no plugins, no configuration files, no
+It is deliberately small — six modules, no plugins, no configuration files, no
 state on disk.
 
 ## System context
@@ -28,14 +28,22 @@ artifact is a wheel.
 | Module | Responsibility |
 | --- | --- |
 | `__init__.py` | Public API surface. Re-exports the exceptions eagerly and resolves `HTTPClient` lazily via PEP 562. |
-| `__main__.py` | Process entry point for both `python -m snaffle` and the `snaffle` console script. Its only logic is turning `KeyboardInterrupt` into a clean exit. |
+| `__main__.py` | Process entry point for both `python -m snaffle` and the `snaffle` console script. The single process-level exit point: it turns `KeyboardInterrupt` into a clean exit, and `cli.main`'s returned code into the process status. |
 | `cli.py` | Argument parsing, header and body parsing, response rendering, error-to-exit-code mapping. Imports `HTTPClient` only after the help paths have been ruled out. |
-| `http_client.py` | The client: session construction, retry policy, method validation, progress streaming, exception translation. |
+| `http_client.py` | The client: session construction, retry policy, method validation, exception translation. Asks `_download` whether to buffer a body, and hands it the body when the answer is yes. |
+| `_download.py` | Private. Owns the progress-bar download whole: whether to drain, the size threshold, the deferred `tqdm` import, the chunk loop, and writing the buffer back onto the response. |
 | `exceptions.py` | Three exception classes. No dependencies, not even on `requests`. |
 
 The dependency graph is acyclic and shallow. `exceptions` depends on nothing;
-`http_client` depends on `exceptions` and the HTTP stack; `cli` depends on
-`exceptions` at import time and on `http_client` at call time.
+`_download` depends on the HTTP stack; `http_client` depends on `exceptions`,
+`_download`, and the HTTP stack; `cli` depends on `exceptions` at import time
+and on `http_client` at call time.
+
+`_download` imports `requests` at module scope, as `http_client` does. That is
+safe because nothing reaches `_download` except through `http_client`, and
+`http_client` itself is only imported once a request is actually being made —
+see [ADR 0002](decisions/0002-lazy-imports-on-the-cli-help-path.md). `tqdm`
+stays deferred inside `_download`, to a function.
 
 Imports of first-party code are absolute throughout — `from snaffle.exceptions
 import ...`, never relative.
@@ -113,8 +121,17 @@ guarded by a test that runs a subprocess and asserts `requests` is absent from
 ### `GET` streams only when something consumes the stream
 
 Streaming a body that nothing reads holds a connection open for the lifetime of
-the response. `GET` therefore streams only when a progress bar is being fed. A
-caller who passes `stream=True` explicitly still gets an unconsumed response.
+the response. `GET` therefore streams on the client's own initiative only when a
+progress bar is being fed. A caller who passes `stream=True` explicitly still
+gets an unconsumed response: their request wins over the bar, because a bar is
+fed by reading the body and reading it is what they asked to do themselves.
+
+That whole decision lives in `_download.should_buffer`, not in `make_request`.
+Draining reaches past the seam three times — it forces `stream=True`, writes
+`response._content`, and writes `response._content_consumed` — so it is worth a
+module with a name on it rather than four inline branches. An earlier revision
+had it inline, and the `stream=True` opt-out above was documented in three
+places while the code did the opposite.
 
 ### The distribution is typed
 
@@ -133,7 +150,9 @@ kinds, and the split is load-bearing:
   Verifies the policy object without any I/O.
 - **Against a real socket** — `TestRetryAgainstRealServer` starts a
   `ThreadingHTTPServer` on an ephemeral port and counts arriving requests. This
-  is the only way to observe retries end to end.
+  is the only way to observe retries end to end. `TestProgressAgainstRealServer`
+  does the same for the streaming opt-out, which needs a real body to prove the
+  socket is still unread.
 
 The class docstring on `TestRetryPolicy` records why: an earlier revision
 claimed "a `POST` is never silently re-sent" on the strength of a

--- a/docs/guides/downloading-large-files.md
+++ b/docs/guides/downloading-large-files.md
@@ -56,8 +56,9 @@ response is closed. Consume it promptly, or close it.
 
 ## Combine your own progress bar with streaming
 
-`show_progress` only drives the client's internal bar, which buffers. To stream
-*and* display progress, drive `tqdm` yourself:
+`show_progress` only drives the client's internal bar, which buffers. Passing
+`stream=True` switches that bar off, so the two never contend for the body. To
+stream *and* display progress, drive `tqdm` yourself:
 
 ```python
 from snaffle import HTTPClient
@@ -89,6 +90,12 @@ changes `GET` in three ways:
 
 The result is a fully-read response, identical in behaviour to a non-streamed
 one. The memory cost is the whole body.
+
+Passing `stream=True` yourself opts out of all three. The body is left unread
+for you to iterate and no bar is drawn — a bar is fed by reading the body, and
+reading it is what you asked to do yourself. See
+[Combine your own progress bar with streaming](#combine-your-own-progress-bar-with-streaming)
+for having both.
 
 Without `show_progress`, `GET` does not stream at all: letting `requests` read
 the body in one pass is faster and returns the connection to the pool

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -142,9 +142,13 @@ the adapter where urllib3's retry logic lives, so it never observes a retry —
 an earlier revision of this project shipped a false claim about `POST` retry
 behaviour on exactly that mistake.
 
-Test against a real socket (`TestRetryAgainstRealServer` in
+Substitute the transport at the client's interface instead: pass a session,
+`HTTPClient(session=...)`, with your own adapter mounted on it. The adapter and
+its retry loop stay in place, so retries happen and can be counted. Failing
+that, test against a real socket (`TestRetryAgainstRealServer` in
 `tests/test_http_client.py`) or assert on `urllib3.util.retry.Retry` directly.
-See the [contributing notes](../../CONTRIBUTING.md#testing-notes).
+See the [contributing notes](../../CONTRIBUTING.md#testing-notes) and
+[Passing a session](../reference/python-api.md#passing-a-session).
 
 ## `mypy` fails with "Duplicate module named 'snaffle'"
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -171,8 +171,13 @@ Response Body:
 | Code | Meaning |
 | --- | --- |
 | `0` | Request succeeded, help was printed, or the user pressed `Ctrl+C`. |
-| `1` | Invalid JSON body, malformed `-H` header, or any `HTTPClientError` — connection failure, non-2xx status, or timeout. |
-| `2` | argparse rejected the command line (unknown command, missing URL, `--progress` on a non-`GET`). |
+| `1` | Invalid JSON body, malformed `-H` header, an argument value the client rejects (`-t 0`, since the timeout must be greater than zero), or any `HTTPClientError` — connection failure, non-2xx status, or timeout. |
+| `2` | argparse rejected the command line (unknown command, missing URL, a non-integer `-t`, `--progress` on a non-`GET`). |
+
+`0` and `1` are returned by `snaffle.cli.main`, which is where the whole mapping
+is decided; `snaffle.__main__.run` passes that return value to `sys.exit`. `2`
+never passes through `main` at all — argparse exits from inside `parse_args`,
+before there is a return value to produce.
 
 A non-2xx status is an error: `raise_for_status()` runs before the response is
 printed, so a `404` exits `1` and prints `Error: HTTP error occurred: ...`

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -195,10 +195,11 @@ with HTTPClient() as client:
 ### `ProgressBar`
 
 A `typing.Protocol` describing the two `tqdm` methods the client uses —
-`update(n)` and `close()`. It is defined in the private `snaffle._download`
-module, alongside the code that builds a bar, and exported from
-`snaffle.http_client` for typing purposes — that remains its supported import
-path. The client does not accept an injected progress bar.
+`update(n)` and `close()`. It is defined in `snaffle.http_client`, which is its
+supported import path. The private `snaffle._download` module builds the bars
+and refers to the protocol under `TYPE_CHECKING` only, so the run-time
+dependency between the two still runs one way. The client does not accept an
+injected progress bar.
 
 ## Exceptions
 

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -26,6 +26,7 @@ HTTPClient(
     retries: int = 3,
     verbose: bool = False,
     show_progress: bool = False,
+    session: requests.Session | None = None,
 ) -> HTTPClient
 ```
 
@@ -42,19 +43,50 @@ call `close()`.
 | `retries` | `int` | `3` | Total attempts for a failed request, not retries after the first. Must be `> 0`; `ValueError` otherwise. Translated to `urllib3.util.retry.Retry(total=retries - 1)`. |
 | `verbose` | `bool` | `False` | Print the outgoing request, the response status and headers, and the underlying `requests` exception behind any failure, each prefixed `[VERBOSE]`. |
 | `show_progress` | `bool` | `False` | Stream `GET` responses and draw a `tqdm` bar once `Content-Length` reaches `MIN_SIZE_FOR_PROGRESS`. A caller who passes `stream=True` opts out; see [`make_request`](#make_request). |
+| `session` | `requests.Session \| None` | `None` | The session to send through. `None` builds the pooled, retrying session described above. A session passed here is used exactly as it arrives; see below. |
 
 Validation runs in `__init__`, before any network access.
+
+#### Passing a session
+
+Two rules apply to a session you supply, and neither is guessed at:
+
+- **`retries` does not apply to it.** The retry policy and the connection pool
+  both come from the session's mounted adapters, so they arrive with the
+  session. `retries` builds the default session and nothing else — it is still
+  validated, still stored on `client.retries`, and has no effect on a session
+  you passed. Passing both is not an error: a caller who mounts a five-attempt
+  adapter may reasonably want `client.retries` to say `5`.
+- **The client will not close it.** `close()` and `__exit__` close only a
+  session the client built, because one you passed may be shared with other
+  clients or outlive this one. Closing it is yours to do.
+
+It is the last parameter, so existing positional calls are unaffected; pass it
+by keyword. Its use is substituting the transport — in tests, mounting an
+adapter on a session you pass is the only substitution above the socket that
+leaves urllib3's retry loop in place, and it needs no patching. See
+[ADR 0004](../architecture/decisions/0004-inject-the-session.md).
+
+```python
+session = requests.Session()
+session.mount("https://", my_adapter)
+
+with HTTPClient(session=session) as client:   # client sends through my_adapter
+    client.get("https://example.com")
+
+session.close()                               # the client did not
+```
 
 ### Instance attributes
 
 | Attribute | Type | Notes |
 | --- | --- | --- |
 | `timeout` | `int` | As constructed. |
-| `retries` | `int` | As constructed. |
+| `retries` | `int` | As constructed. Applied to the default session only; see [Passing a session](#passing-a-session). |
 | `verbose` | `bool` | As constructed. |
 | `show_progress` | `bool` | As constructed. |
 | `allowed_methods` | `frozenset[str]` | The methods this instance accepts. Initialised from `ALLOWED_METHODS` and read on every request. |
-| `session` | `requests.Session` | The pooled session, with the retrying adapter mounted on `http://` and `https://`. |
+| `session` | `requests.Session` | The session requests go through: the one passed to the constructor, or a pooled one with the retrying adapter mounted on `http://` and `https://`. |
 
 The class defines no `__slots__`: instances stay weak-referenceable and accept
 arbitrary attributes.
@@ -146,10 +178,14 @@ client.close() -> None
 
 Closes the session and releases pooled connections. Idempotent.
 
+Only a session the client built. A session passed to the constructor is left
+open — see [Passing a session](#passing-a-session).
+
 #### `__enter__` / `__exit__`
 
 `HTTPClient` is a context manager. `__enter__` returns the client; `__exit__`
-calls `close()` and suppresses nothing.
+calls `close()` and suppresses nothing — including, therefore, leaving an
+injected session open.
 
 ```python
 with HTTPClient() as client:
@@ -213,4 +249,10 @@ inside the adapter and becomes an `HTTPConnectionError`. See
 [Raises](#make_request) above.
 
 Because retries happen inside the adapter, mocking `requests.Session.request`
-cannot observe them — see [contributing](../../CONTRIBUTING.md#testing-notes).
+cannot observe them. A test that needs to see them substitutes the session
+instead, which leaves the adapter underneath it — see
+[Passing a session](#passing-a-session) and
+[contributing](../../CONTRIBUTING.md#testing-notes).
+
+The policy in this table is the one `HTTPClient` builds. A session you pass
+carries whatever policy its own adapters were mounted with.

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -41,7 +41,7 @@ call `close()`.
 | `timeout` | `int` | `30` | Seconds before a request times out. Must be `> 0`; `ValueError` otherwise. |
 | `retries` | `int` | `3` | Total attempts for a failed request, not retries after the first. Must be `> 0`; `ValueError` otherwise. Translated to `urllib3.util.retry.Retry(total=retries - 1)`. |
 | `verbose` | `bool` | `False` | Print the outgoing request, the response status and headers, and the underlying `requests` exception behind any failure, each prefixed `[VERBOSE]`. |
-| `show_progress` | `bool` | `False` | Stream `GET` responses and draw a `tqdm` bar once `Content-Length` reaches `MIN_SIZE_FOR_PROGRESS`. |
+| `show_progress` | `bool` | `False` | Stream `GET` responses and draw a `tqdm` bar once `Content-Length` reaches `MIN_SIZE_FOR_PROGRESS`. A caller who passes `stream=True` opts out; see [`make_request`](#make_request). |
 
 Validation runs in `__init__`, before any network access.
 
@@ -100,17 +100,20 @@ client.make_request(method: str, url: str, **kwargs: Any) -> requests.Response
 ```
 
 The single path all seven wrappers take. It validates and upper-cases `method`,
-sets `stream=True` when `show_progress` is on and the method is `GET`, sends the
-request with the client's `timeout`, calls `raise_for_status()`, and translates
+sets `stream=True` when it is going to feed a progress bar, sends the request
+with the client's `timeout`, calls `raise_for_status()`, and translates
 `requests` exceptions into this package's hierarchy.
 
 When progress tracking is active it drains the body into `response._content` and
 marks it consumed, so `.text` and `.json()` serve the buffer rather than
 re-reading a drained socket.
 
-Passing `stream=True` yourself does not trigger that draining: you get an
-unconsumed response to iterate. Passing `stream=True` on a `GET` while
-`show_progress` is on has no additional effect — the client sets it anyway.
+Passing `stream=True` yourself opts out of that draining, whatever
+`show_progress` says: you get an unconsumed response to iterate, and no bar is
+drawn. The two cannot both hold — a bar is fed by reading the body, and reading
+the body is what you asked to do yourself. To have both, drive `tqdm` from your
+own loop; see
+[Download large files](../guides/downloading-large-files.md#combine-your-own-progress-bar-with-streaming).
 
 Raises:
 
@@ -156,8 +159,10 @@ with HTTPClient() as client:
 ### `ProgressBar`
 
 A `typing.Protocol` describing the two `tqdm` methods the client uses —
-`update(n)` and `close()`. Exported from `snaffle.http_client` for typing
-purposes; the client does not accept an injected progress bar.
+`update(n)` and `close()`. It is defined in the private `snaffle._download`
+module, alongside the code that builds a bar, and exported from
+`snaffle.http_client` for typing purposes — that remains its supported import
+path. The client does not accept an injected progress bar.
 
 ## Exceptions
 

--- a/src/snaffle/__main__.py
+++ b/src/snaffle/__main__.py
@@ -3,6 +3,10 @@
 This module allows the snaffle application to be executed as a package
 by running `python -m snaffle`. It handles the initial execution and
 catches common exceptions like `KeyboardInterrupt`.
+
+`cli.main` reports its outcome as a return value rather than raising
+`SystemExit`, so this is where that code becomes the process exit status. The
+one exit that still happens elsewhere is argparse's `2` for a bad command line.
 """
 
 import sys
@@ -11,10 +15,14 @@ from snaffle.cli import main
 
 
 def run() -> None:
-    """Run the package entrypoint and handle user cancellation cleanly."""
+    """Run the package entrypoint, exiting with the code the CLI returns.
+
+    `Ctrl+C` is the one outcome the CLI does not report as a return value; it
+    is caught here and reported as a clean exit `0`.
+    """
 
     try:
-        main()
+        sys.exit(main())
     except KeyboardInterrupt:
         print("\nOperation cancelled by user")
         sys.exit(0)

--- a/src/snaffle/_download.py
+++ b/src/snaffle/_download.py
@@ -1,0 +1,121 @@
+"""Progress-bar buffering for downloads.
+
+`snaffle.http_client` delegates a single decision here: whether the client
+should ask for an unread body and drain it itself, so that a progress bar can be
+fed as the bytes arrive. Everything that decision entails lives in this module
+-- the size threshold, the deferred `tqdm` import, the chunk loop, and the
+write-back of the buffered body onto the response.
+
+The module is private. It is reachable only through `snaffle.http_client`, which
+is itself imported lazily, so importing `requests` at module scope here does not
+undo the start-up win recorded in ADR 0002. `tests/test_init.py` guards that.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol, cast
+
+import requests
+
+
+class ProgressBar(Protocol):
+    """Protocol for the subset of progress-bar methods used by the client."""
+
+    def update(self, n: float | None = 1) -> bool | None:
+        """Advance the progress display by the provided number of bytes."""
+
+    def close(self) -> None:
+        """Close the progress display and release any related resources."""
+
+
+def should_buffer(method: str, show_progress: bool, kwargs: Mapping[str, Any]) -> bool:
+    """Reports whether the client should stream the body itself to feed a bar.
+
+    Streaming a body that nothing reads holds a connection open for the lifetime
+    of the response, so the client only does it on its own initiative when there
+    is a progress bar to feed: a `GET` with `show_progress` on.
+
+    A caller who passed `stream=True` is going to read the body themselves and
+    must get it unconsumed, so their request wins and no bar is drawn. An
+    explicit `stream=False` does not opt out -- buffering ends in a fully-read
+    response, which is what that caller asked for either way.
+
+    Args:
+        method (str): The normalized HTTP method.
+        show_progress (bool): The client's `show_progress` setting.
+        kwargs (Mapping[str, Any]): The keyword arguments bound for `requests`.
+
+    Returns:
+        bool: True when the client should request a stream and drain it itself.
+    """
+    return method == "GET" and show_progress and not kwargs.get("stream", False)
+
+
+def buffer_into(
+    response: requests.Response, *, chunk_size: int, min_size: int, desc: str
+) -> None:
+    """Drains the body through a progress bar and attaches it to the response.
+
+    A bar is drawn only once the response's `Content-Length` reaches `min_size`;
+    below that -- and when the server sends no length at all, which reads as
+    `0` -- the body is still drained, just silently.
+
+    The buffer is written back onto the response and the body marked consumed, so
+    `.text` and `.json()` serve it rather than re-reading a drained socket. The
+    result is indistinguishable from a response `requests` read in one pass; the
+    cost is holding the whole body in memory.
+
+    Args:
+        response (requests.Response): The unread response to drain.
+        chunk_size (int): Bytes to read per `iter_content` chunk.
+        min_size (int): Minimum `Content-Length` before a bar is drawn.
+        desc (str): The description displayed alongside the bar.
+    """
+    total = int(response.headers.get("content-length", 0))
+    progress_bar = _create_progress_bar(total, min_size, desc)
+
+    chunks: list[bytes] = []
+    append = chunks.append
+    update = progress_bar.update if progress_bar is not None else None
+
+    try:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+            if not chunk:
+                continue
+
+            append(chunk)
+            if update is not None:
+                update(len(chunk))
+    finally:
+        if progress_bar is not None:
+            progress_bar.close()
+
+    response._content = b"".join(chunks)
+    # Mark the body as fully read so `.text`/`.json()` serve the buffer we just
+    # built instead of re-reading a drained socket.
+    cast(Any, response)._content_consumed = True
+
+
+def _create_progress_bar(total: int, min_size: int, desc: str) -> ProgressBar | None:
+    """Creates a `tqdm` bar, or None when the transfer is too small to warrant one.
+
+    Args:
+        total (int): The total size of the transfer in bytes.
+        min_size (int): The size at or above which a bar is drawn.
+        desc (str): A description to display with the progress bar.
+
+    Returns:
+        ProgressBar or None: A `tqdm` instance, or None below the threshold.
+    """
+    if total < min_size:
+        return None
+
+    # Imported lazily: tqdm costs ~15ms of startup that a run without a progress
+    # bar should never pay. See ADR 0002.
+    from tqdm import tqdm
+
+    return cast(
+        ProgressBar,
+        tqdm(total=total, unit="B", unit_scale=True, desc=desc),
+    )

--- a/src/snaffle/_download.py
+++ b/src/snaffle/_download.py
@@ -14,19 +14,15 @@ undo the start-up win recorded in ADR 0002. `tests/test_init.py` guards that.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import requests
 
-
-class ProgressBar(Protocol):
-    """Protocol for the subset of progress-bar methods used by the client."""
-
-    def update(self, n: float | None = 1) -> bool | None:
-        """Advance the progress display by the provided number of bytes."""
-
-    def close(self) -> None:
-        """Close the progress display and release any related resources."""
+if TYPE_CHECKING:
+    # Type-only, so the run-time dependency still runs one way: `http_client`
+    # imports this module, never the reverse. `ProgressBar` is documented as
+    # part of `http_client`'s surface, so it is defined there.
+    from snaffle.http_client import ProgressBar
 
 
 def should_buffer(method: str, show_progress: bool, kwargs: Mapping[str, Any]) -> bool:
@@ -115,7 +111,9 @@ def _create_progress_bar(total: int, min_size: int, desc: str) -> ProgressBar | 
     # bar should never pay. See ADR 0002.
     from tqdm import tqdm
 
+    # The target is quoted: `ProgressBar` is imported for type checking only, so
+    # the name does not exist when `cast` evaluates its arguments at run time.
     return cast(
-        ProgressBar,
+        "ProgressBar",
         tqdm(total=total, unit="B", unit_scale=True, desc=desc),
     )

--- a/src/snaffle/cli.py
+++ b/src/snaffle/cli.py
@@ -216,15 +216,26 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> None:
+def main(argv: Sequence[str] | None = None) -> int:
     """The main entry point for the snaffle CLI.
 
     This function parses command-line arguments, initializes the HTTP client,
     and executes the requested HTTP command. It also handles response printing
     and error reporting.
 
+    It returns the exit code rather than raising ``SystemExit``, so the whole
+    error-to-code mapping is readable here and testable without a subprocess.
+    ``snaffle.__main__.run`` is what turns the code into a process exit. The one
+    code this function cannot return is ``2``: ``argparse`` exits with it from
+    inside ``parse_args`` below, before there is anything to return.
+
     Args:
         argv (Sequence[str], optional): Arguments to parse. Defaults to ``sys.argv``.
+
+    Returns:
+        int: ``0`` when the request succeeded or help was printed; ``1`` for an
+        invalid JSON body, a malformed ``-H`` header, an argument the client
+        rejects (such as ``-t 0``), or any ``HTTPClientError``.
     """
     parser = create_parser()
     args = parser.parse_args(argv)
@@ -235,7 +246,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         parser.print_help()
         print("\n")
         print(EXAMPLES)
-        return
+        return 0
 
     # Deferred so the help paths above never import the HTTP stack.
     from snaffle.http_client import HTTPClient
@@ -254,8 +265,10 @@ def main(argv: Sequence[str] | None = None) -> None:
         print("Error: Invalid JSON data")
         print("Make sure your JSON data is properly formatted.")
         print('Example: \'{"key": "value"}\'')
-        sys.exit(1)
+        return 1
     except (ValueError, HTTPClientError) as error:
         # json.JSONDecodeError is a ValueError, so it must be caught above this.
         print(f"Error: {error}")
-        sys.exit(1)
+        return 1
+
+    return 0

--- a/src/snaffle/http_client.py
+++ b/src/snaffle/http_client.py
@@ -39,6 +39,17 @@ class HTTPClient:
         with HTTPClient() as client:
             client.get("https://example.com")
 
+    The session is built by :meth:`_build_session` unless one is passed to the
+    constructor. **A client closes only a session it built**: one it was given
+    belongs to the caller, who may be sharing it, and closing it would pull the
+    pool out from under them.
+
+    Passing a session is how the transport is substituted without patching
+    `requests.Session.request` -- a mock there sits above the adapter and cannot
+    observe a retry. An injected session brings its own adapters, so it also
+    brings its own retry policy and connection pool; `retries` builds the default
+    session and does not reach one supplied here.
+
     Retries use exponential backoff and are applied to:
 
     * connection failures, for every method -- a request that never reached the
@@ -79,6 +90,7 @@ class HTTPClient:
         retries: int = 3,
         verbose: bool = False,
         show_progress: bool = False,
+        session: requests.Session | None = None,
     ) -> None:
         """Initializes the HTTPClient with configuration options.
 
@@ -87,6 +99,12 @@ class HTTPClient:
             retries (int, optional): The total number of attempts for failed requests. Defaults to 3.
             verbose (bool, optional): Whether to enable verbose logging. Defaults to False.
             show_progress (bool, optional): Whether to show a progress bar for large downloads. Defaults to False.
+            session (requests.Session, optional): A session to send through. Defaults
+                to one built by :meth:`_build_session`. A session passed here is
+                used as it arrives: `retries` builds the default session and is not
+                applied to this one, because the retry policy and the connection
+                pool both come from the session's mounted adapters. The client does
+                not close a session it did not build; see :meth:`close`.
         """
         if timeout <= 0:
             raise ValueError("timeout must be greater than 0")
@@ -98,7 +116,8 @@ class HTTPClient:
         self.verbose = verbose
         self.show_progress = show_progress
         self.allowed_methods = self.ALLOWED_METHODS
-        self.session = self._build_session(retries)
+        self._owns_session = session is None
+        self.session = self._build_session(retries) if session is None else session
 
     @classmethod
     def _build_session(cls, retries: int) -> requests.Session:
@@ -128,8 +147,14 @@ class HTTPClient:
         return session
 
     def close(self) -> None:
-        """Closes the underlying session and releases pooled connections."""
-        self.session.close()
+        """Closes the session this client built, releasing pooled connections.
+
+        A session passed to the constructor belongs to the caller, who may be
+        sharing it with other clients, so it is left open. Closing it is theirs
+        to do.
+        """
+        if self._owns_session:
+            self.session.close()
 
     def __enter__(self) -> HTTPClient:
         """Returns the client itself, for use as a context manager."""
@@ -141,7 +166,10 @@ class HTTPClient:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        """Closes the session on exit, suppressing nothing."""
+        """Calls :meth:`close` on exit, suppressing nothing.
+
+        An injected session is left open, as it is by :meth:`close`.
+        """
         self.close()
 
     def _validate_method(self, method: str) -> str:
@@ -233,86 +261,35 @@ class HTTPClient:
                 print(f"[VERBOSE] RequestException: {e}")
             raise HTTPClientError(f"Request failed: {e!s}") from e
 
+    # The seven verb methods below are `make_request` with the method fixed.
+    # They carry no behaviour of their own, so they do not restate its contract:
+    # arguments, return value and exceptions are documented once, there and in
+    # `docs/reference/python-api.md`, rather than seven times over here.
+
     def get(self, url: str, **kwargs: Any) -> requests.Response:
-        """Sends a GET request to the specified URL.
-
-        Args:
-            url (str): The URL to send the GET request to.
-            **kwargs: Additional keyword arguments for the request.
-
-        Returns:
-            requests.Response: The HTTP response object.
-        """
+        """Sends a GET request. See :meth:`make_request` for the contract."""
         return self.make_request("GET", url, **kwargs)
 
     def post(self, url: str, **kwargs: Any) -> requests.Response:
-        """Sends a POST request to the specified URL.
-
-        Args:
-            url (str): The URL to send the POST request to.
-            **kwargs: Additional keyword arguments for the request, such as `json` or `data`.
-
-        Returns:
-            requests.Response: The HTTP response object.
-        """
+        """Sends a POST request. See :meth:`make_request` for the contract."""
         return self.make_request("POST", url, **kwargs)
 
     def put(self, url: str, **kwargs: Any) -> requests.Response:
-        """Sends a PUT request to the specified URL.
-
-        Args:
-            url (str): The URL to send the PUT request to.
-            **kwargs: Additional keyword arguments for the request, such as `json` or `data`.
-
-        Returns:
-            requests.Response: The HTTP response object.
-        """
+        """Sends a PUT request. See :meth:`make_request` for the contract."""
         return self.make_request("PUT", url, **kwargs)
 
     def patch(self, url: str, **kwargs: Any) -> requests.Response:
-        """Sends a PATCH request to the specified URL.
-
-        Args:
-            url (str): The URL to send the PATCH request to.
-            **kwargs: Additional keyword arguments for the request, such as `json` or `data`.
-
-        Returns:
-            requests.Response: The HTTP response object.
-        """
+        """Sends a PATCH request. See :meth:`make_request` for the contract."""
         return self.make_request("PATCH", url, **kwargs)
 
     def delete(self, url: str, **kwargs: Any) -> requests.Response:
-        """Sends a DELETE request to the specified URL.
-
-        Args:
-            url (str): The URL to send the DELETE request to.
-            **kwargs: Additional keyword arguments for the request.
-
-        Returns:
-            requests.Response: The HTTP response object.
-        """
+        """Sends a DELETE request. See :meth:`make_request` for the contract."""
         return self.make_request("DELETE", url, **kwargs)
 
     def head(self, url: str, **kwargs: Any) -> requests.Response:
-        """Sends a HEAD request to the specified URL.
-
-        Args:
-            url (str): The URL to send the HEAD request to.
-            **kwargs: Additional keyword arguments for the request.
-
-        Returns:
-            requests.Response: The HTTP response object.
-        """
+        """Sends a HEAD request. See :meth:`make_request` for the contract."""
         return self.make_request("HEAD", url, **kwargs)
 
     def options(self, url: str, **kwargs: Any) -> requests.Response:
-        """Sends an OPTIONS request to the specified URL.
-
-        Args:
-            url (str): The URL to send the OPTIONS request to.
-            **kwargs: Additional keyword arguments for the request.
-
-        Returns:
-            requests.Response: The HTTP response object.
-        """
+        """Sends an OPTIONS request. See :meth:`make_request` for the contract."""
         return self.make_request("OPTIONS", url, **kwargs)

--- a/src/snaffle/http_client.py
+++ b/src/snaffle/http_client.py
@@ -12,23 +12,18 @@ of paying for a fresh handshake each time.
 from __future__ import annotations
 
 from types import TracebackType
-from typing import Any, Protocol, cast
+from typing import Any
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from snaffle._download import ProgressBar, buffer_into, should_buffer
 from snaffle.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
 
-
-class ProgressBar(Protocol):
-    """Protocol for the subset of progress-bar methods used by the client."""
-
-    def update(self, n: float | None = 1) -> bool | None:
-        """Advance the progress display by the provided number of bytes."""
-
-    def close(self) -> None:
-        """Close the progress display and release any related resources."""
+#: `ProgressBar` lives in `_download` with the code that builds one, but it is
+#: documented as importable from here, so it stays part of this module's surface.
+__all__ = ["HTTPClient", "ProgressBar"]
 
 
 class HTTPClient:
@@ -159,71 +154,17 @@ class HTTPClient:
             )
         return normalized_method
 
-    def _create_progress_bar(self, total: int, desc: str) -> ProgressBar | None:
-        """Creates a `tqdm` progress bar if conditions are met.
-
-        A progress bar is created if `show_progress` is True and the file size (`total`)
-        is greater than or equal to `MIN_SIZE_FOR_PROGRESS`.
-
-        Args:
-            total (int): The total size of the file transfer in bytes.
-            desc (str): A description to display with the progress bar.
-
-        Returns:
-            ProgressBar or None: A `tqdm` progress bar instance or `None` if the conditions are not met.
-        """
-        if self.show_progress and total >= self.MIN_SIZE_FOR_PROGRESS:
-            # Imported lazily: tqdm costs ~15ms of startup that a CLI run
-            # without --progress should never pay.
-            from tqdm import tqdm
-
-            return cast(
-                ProgressBar,
-                tqdm(total=total, unit="B", unit_scale=True, desc=desc),
-            )
-        return None
-
-    def _stream_response(
-        self,
-        response: requests.Response,
-        progress_bar: ProgressBar | None = None,
-    ) -> bytes:
-        """Streams the response content and updates the progress bar.
-
-        This method iterates over the response content in chunks, allowing for efficient
-        handling of large responses and real-time progress updates.
-
-        Args:
-            response (requests.Response): The HTTP response object.
-            progress_bar (ProgressBar, optional): The progress bar instance to update. Defaults to None.
-
-        Returns:
-            bytes: The full response content as a byte string.
-        """
-        chunks: list[bytes] = []
-        append = chunks.append
-        update = progress_bar.update if progress_bar is not None else None
-
-        try:
-            for chunk in response.iter_content(chunk_size=self.DOWNLOAD_CHUNK_SIZE):
-                if not chunk:
-                    continue
-
-                append(chunk)
-                if update is not None:
-                    update(len(chunk))
-        finally:
-            if progress_bar is not None:
-                progress_bar.close()
-
-        return b"".join(chunks)
-
     def make_request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
         """Makes an HTTP request with retry logic and error handling.
 
         This is the core method for all HTTP operations performed by the client.
         Retries with exponential backoff are handled by the session's adapter;
         see the class docstring for which failures are retried for which methods.
+
+        A `GET` sent while `show_progress` is on streams its body and drains it
+        through a progress bar into a buffer, so the response that comes back is
+        fully read. A caller who passes `stream=True` opts out of that: the body
+        is left unread for them to iterate, and no bar is drawn.
 
         Args:
             method (str): The HTTP method to use (e.g., 'GET', 'POST').
@@ -242,12 +183,12 @@ class HTTPClient:
         normalized_method = self._validate_method(method)
         verbose = self.verbose
 
-        # We only stream on our own initiative when there is a progress bar to
-        # feed; otherwise letting requests read the body in one pass is faster
-        # and returns the connection to the pool immediately. A caller who asked
-        # for `stream=True` still gets an unconsumed response to iterate itself.
-        track_progress = normalized_method == "GET" and self.show_progress
-        if track_progress:
+        # Whether the body is worth streaming and draining ourselves is
+        # `_download`'s decision, including the opt-out for a caller who passed
+        # `stream=True` and will read the body themselves. All this method does
+        # is switch the transport into streaming mode when the answer is yes.
+        buffer_body = should_buffer(normalized_method, self.show_progress, kwargs)
+        if buffer_body:
             kwargs["stream"] = True
 
         if verbose:
@@ -266,13 +207,13 @@ class HTTPClient:
                     f"[VERBOSE] Received response with status {response.status_code} and headers {response.headers}"
                 )
 
-            if track_progress:
-                total = int(response.headers.get("content-length", 0))
-                progress_bar = self._create_progress_bar(total, f"Downloading {url}")
-                response._content = self._stream_response(response, progress_bar)
-                # Mark the body as fully read so `.text`/`.json()` serve the
-                # buffer we just built instead of re-reading a drained socket.
-                cast(Any, response)._content_consumed = True
+            if buffer_body:
+                buffer_into(
+                    response,
+                    chunk_size=self.DOWNLOAD_CHUNK_SIZE,
+                    min_size=self.MIN_SIZE_FOR_PROGRESS,
+                    desc=f"Downloading {url}",
+                )
 
             return response
 

--- a/src/snaffle/http_client.py
+++ b/src/snaffle/http_client.py
@@ -12,18 +12,32 @@ of paying for a fresh handshake each time.
 from __future__ import annotations
 
 from types import TracebackType
-from typing import Any
+from typing import Any, Protocol
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from snaffle._download import ProgressBar, buffer_into, should_buffer
+from snaffle._download import buffer_into, should_buffer
 from snaffle.exceptions import HTTPClientError, HTTPConnectionError, ResponseError
 
-#: `ProgressBar` lives in `_download` with the code that builds one, but it is
-#: documented as importable from here, so it stays part of this module's surface.
 __all__ = ["HTTPClient", "ProgressBar"]
+
+
+class ProgressBar(Protocol):
+    """Protocol for the subset of progress-bar methods used by the client.
+
+    Defined here because it is documented as part of this module's surface.
+    `_download` builds the bars and refers to this protocol under
+    `TYPE_CHECKING` only, so the dependency between the two modules still runs
+    one way at run time.
+    """
+
+    def update(self, n: float | None = 1) -> bool | None:
+        """Advance the progress display by the provided number of bytes."""
+
+    def close(self) -> None:
+        """Close the progress display and release any related resources."""
 
 
 class HTTPClient:
@@ -166,10 +180,7 @@ class HTTPClient:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        """Calls :meth:`close` on exit, suppressing nothing.
-
-        An injected session is left open, as it is by :meth:`close`.
-        """
+        """Calls :meth:`close` on exit, suppressing nothing."""
         self.close()
 
     def _validate_method(self, method: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from snaffle.cli import EXAMPLES, main
+from snaffle.exceptions import HTTPClientError
 
 MAKE_REQUEST = "snaffle.http_client.HTTPClient.make_request"
 
@@ -30,11 +31,12 @@ class TestCLI(unittest.TestCase):
         )
 
     def test_help_command(self) -> None:
-        """Test the HELP command prints the usage examples."""
+        """Test the HELP command prints the usage examples and returns 0."""
         with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
-            main(["HELP"])
+            exit_code = main(["HELP"])
 
         output = fake_stdout.getvalue()
+        self.assertEqual(exit_code, 0)
         self.assertIn("Examples:", output)
         self.assertIn("Normal GET request:", output)
         self.assertIn(EXAMPLES, output)
@@ -42,8 +44,9 @@ class TestCLI(unittest.TestCase):
     def test_no_command_prints_help(self) -> None:
         """Test a bare invocation falls back to the same help path."""
         with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
-            main([])
+            exit_code = main([])
 
+        self.assertEqual(exit_code, 0)
         self.assertIn("Examples:", fake_stdout.getvalue())
 
     @patch(MAKE_REQUEST)
@@ -52,9 +55,10 @@ class TestCLI(unittest.TestCase):
         mock_request.return_value = self._build_response(text="Success")
 
         with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
-            main(["GET", "https://api.example.com"])
+            exit_code = main(["GET", "https://api.example.com"])
 
         output = fake_stdout.getvalue()
+        self.assertEqual(exit_code, 0)
         self.assertIn("Status Code: 200", output)
         self.assertIn("Headers:", output)
         self.assertIn("Response Body:", output)
@@ -95,28 +99,59 @@ class TestCLI(unittest.TestCase):
         mock_request.assert_called_once_with("GET", "https://api.example.com")
 
     def test_progress_is_not_available_for_post(self) -> None:
-        """Test that --progress is not available for POST command."""
+        """Test --progress on POST is an argparse error, which still exits 2.
+
+        argparse exits from inside `parse_args`, so this code never reaches
+        `main`'s return value; see the CLI reference on exit codes.
+        """
         with (
-            self.assertRaises(SystemExit),
+            self.assertRaises(SystemExit) as caught,
             patch("sys.stderr", new_callable=io.StringIO),
         ):
             main(["POST", "https://api.example.com", "--progress"])
 
-    def test_invalid_header_value_exits_with_error(self) -> None:
+        self.assertEqual(caught.exception.code, 2)
+
+    def test_invalid_header_value_returns_one(self) -> None:
         """Test invalid header formatting returns a CLI error."""
         fake_stdout = io.StringIO()
-        with self.assertRaises(SystemExit), patch("sys.stdout", new=fake_stdout):
-            main(["GET", "https://api.example.com", "-H", "Authorization"])
+        with patch("sys.stdout", new=fake_stdout):
+            exit_code = main(["GET", "https://api.example.com", "-H", "Authorization"])
 
+        self.assertEqual(exit_code, 1)
         self.assertIn("Invalid header format", fake_stdout.getvalue())
 
-    def test_invalid_json_value_exits_with_error(self) -> None:
+    def test_invalid_json_value_returns_one(self) -> None:
         """Test invalid JSON data returns a CLI error."""
         fake_stdout = io.StringIO()
-        with self.assertRaises(SystemExit), patch("sys.stdout", new=fake_stdout):
-            main(["POST", "https://api.example.com", "-d", "{not-json}"])
+        with patch("sys.stdout", new=fake_stdout):
+            exit_code = main(["POST", "https://api.example.com", "-d", "{not-json}"])
 
+        self.assertEqual(exit_code, 1)
         self.assertIn("Invalid JSON data", fake_stdout.getvalue())
+
+    def test_invalid_timeout_returns_one(self) -> None:
+        """Test a timeout the client rejects returns a CLI error.
+
+        `-t 0` passes argparse — it is a valid int — and is refused by
+        `HTTPClient.__init__` with a plain ValueError.
+        """
+        fake_stdout = io.StringIO()
+        with patch("sys.stdout", new=fake_stdout):
+            exit_code = main(["GET", "https://api.example.com", "-t", "0"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Error: timeout must be greater than 0", fake_stdout.getvalue())
+
+    @patch(MAKE_REQUEST, side_effect=HTTPClientError("Connection error occurred"))
+    def test_client_error_returns_one(self, _: MagicMock) -> None:
+        """Test any HTTPClientError is reported and returns a CLI error."""
+        fake_stdout = io.StringIO()
+        with patch("sys.stdout", new=fake_stdout):
+            exit_code = main(["GET", "https://api.example.com"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Error: Connection error occurred", fake_stdout.getvalue())
 
     def test_usage_line_is_stable_across_entry_points(self) -> None:
         """Test help output names the command, not whatever launched it."""

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,138 @@
+"""Test cases for the progress-bar download buffering."""
+
+from __future__ import annotations
+
+import io
+import unittest
+from typing import Any, cast
+from unittest.mock import MagicMock, call, patch
+
+import requests
+
+from snaffle._download import buffer_into, should_buffer
+
+MIB = 1024 * 1024
+
+
+def _unread_response(content_length: str | None, chunks: list[bytes]) -> Any:
+    """Builds a stand-in for an unread response that yields `chunks`."""
+    response = MagicMock()
+    response.headers = (
+        {} if content_length is None else {"content-length": content_length}
+    )
+    response.iter_content.return_value = chunks
+    return response
+
+
+class TestShouldBuffer(unittest.TestCase):
+    """Test cases for deciding whether the client drains a body itself."""
+
+    def test_get_with_progress_buffers(self) -> None:
+        """Test the one case worth streaming for: a GET that can draw a bar."""
+        self.assertTrue(should_buffer("GET", True, {}))
+
+    def test_get_without_progress_does_not_buffer(self) -> None:
+        """Test nothing is streamed when there is no bar to feed."""
+        self.assertFalse(should_buffer("GET", False, {}))
+
+    def test_other_methods_do_not_buffer(self) -> None:
+        """Test the progress bar is a GET feature only."""
+        for method in ("POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"):
+            with self.subTest(method=method):
+                self.assertFalse(should_buffer(method, True, {}))
+
+    def test_explicit_stream_opts_out(self) -> None:
+        """Test a caller who asked to stream keeps the body: no drain, no bar."""
+        self.assertFalse(should_buffer("GET", True, {"stream": True}))
+
+    def test_explicit_stream_false_still_buffers(self) -> None:
+        """Test `stream=False` is not an opt-out: it asks for a read response."""
+        self.assertTrue(should_buffer("GET", True, {"stream": False}))
+
+
+class TestBufferInto(unittest.TestCase):
+    """Test cases for draining a body through a progress bar."""
+
+    def test_body_is_attached_to_the_response_and_marked_consumed(self) -> None:
+        """Test `.text` serves the buffer rather than re-reading a drained socket."""
+        response = requests.Response()
+        response.status_code = 200
+        response.headers["content-length"] = "8"
+        cast(Any, response).raw = io.BytesIO(b"payload!")
+
+        buffer_into(response, chunk_size=4, min_size=MIB, desc="Downloading")
+
+        self.assertEqual(response._content, b"payload!")
+        self.assertTrue(cast(Any, response)._content_consumed)
+        self.assertEqual(response.text, "payload!")
+
+    def test_chunks_are_read_at_the_requested_size(self) -> None:
+        """Test the client's chunk size reaches `iter_content` unchanged."""
+        response = _unread_response("4", [b"data"])
+
+        buffer_into(response, chunk_size=1234, min_size=MIB, desc="Downloading")
+
+        response.iter_content.assert_called_once_with(chunk_size=1234)
+
+    def test_empty_chunks_are_skipped(self) -> None:
+        """Test keep-alive chunks neither reach the buffer nor advance the bar."""
+        response = _unread_response(str(6 * MIB), [b"ab", b"", b"cd"])
+
+        with patch("tqdm.tqdm") as mock_tqdm:
+            buffer_into(response, chunk_size=8, min_size=5 * MIB, desc="Downloading")
+
+        self.assertEqual(response._content, b"abcd")
+        self.assertEqual(
+            mock_tqdm.return_value.update.call_args_list, [call(2), call(2)]
+        )
+
+    def test_bar_is_drawn_at_the_threshold(self) -> None:
+        """Test the size comparison is inclusive: exactly the minimum draws a bar."""
+        response = _unread_response(str(5 * MIB), [b"data"])
+
+        with patch("tqdm.tqdm") as mock_tqdm:
+            buffer_into(response, chunk_size=8, min_size=5 * MIB, desc="Downloading x")
+
+        mock_tqdm.assert_called_once_with(
+            total=5 * MIB, unit="B", unit_scale=True, desc="Downloading x"
+        )
+        mock_tqdm.return_value.close.assert_called_once()
+
+    def test_body_below_the_threshold_is_buffered_without_a_bar(self) -> None:
+        """Test a small download is drained silently."""
+        response = _unread_response(str(4 * MIB), [b"data"])
+
+        with patch("tqdm.tqdm") as mock_tqdm:
+            buffer_into(response, chunk_size=8, min_size=5 * MIB, desc="Downloading")
+
+        mock_tqdm.assert_not_called()
+        self.assertEqual(response._content, b"data")
+
+    def test_missing_content_length_draws_no_bar(self) -> None:
+        """Test a server that sends no length reads as 0, and the body still lands."""
+        response = _unread_response(None, [b"data"])
+
+        with patch("tqdm.tqdm") as mock_tqdm:
+            buffer_into(response, chunk_size=8, min_size=5 * MIB, desc="Downloading")
+
+        mock_tqdm.assert_not_called()
+        self.assertEqual(response._content, b"data")
+
+    def test_bar_is_closed_when_the_body_fails_midway(self) -> None:
+        """Test a broken download does not leave the terminal owned by tqdm."""
+        response = _unread_response(str(6 * MIB), [])
+        response.iter_content.side_effect = requests.exceptions.ChunkedEncodingError(
+            "boom"
+        )
+
+        with (
+            patch("tqdm.tqdm") as mock_tqdm,
+            self.assertRaises(requests.exceptions.ChunkedEncodingError),
+        ):
+            buffer_into(response, chunk_size=8, min_size=5 * MIB, desc="Download")
+
+        mock_tqdm.return_value.close.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -26,6 +26,69 @@ SESSION_REQUEST = "requests.Session.request"
 BUFFER_INTO = "snaffle.http_client.buffer_into"
 
 
+def _adapter_of(client: HTTPClient, url: str = "http://x") -> Any:
+    """Returns the adapter a client would send `url` through."""
+    return client.session.get_adapter(url)
+
+
+def _policy_for(attempts: int) -> Retry:
+    """Returns the retry policy carried by a default client built for `attempts`.
+
+    `attempts` counts total attempts, the same way `HTTPClient(retries=...)`
+    does -- not the way urllib3's `Retry.total` does, which is one fewer.
+    """
+    with HTTPClient(retries=attempts) as client:
+        return cast(Retry, _adapter_of(client).max_retries)
+
+
+class _QuietHandler(BaseHTTPRequestHandler):
+    """A keep-alive handler that does not log every request to stderr."""
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args: Any) -> None:
+        """Discards the per-request log line the base class would print."""
+
+    def send_body(self, code: int, body: bytes) -> None:
+        """Sends one complete response, `Content-Length` included."""
+        self.send_response(code)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class _LocalServerTestCase(unittest.TestCase):
+    """Base for tests that need a real socket. Subclasses supply `handler`.
+
+    A real server is the only way to observe some of what this package promises
+    -- retries happen below `Session.request`, and only a socket has a body to
+    drain -- so two test classes need one. The scaffolding lives here rather
+    than in both.
+    """
+
+    handler: ClassVar[type[BaseHTTPRequestHandler]]
+    server: ClassVar[ThreadingHTTPServer]
+    base_url: ClassVar[str]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Starts the subclass's handler on an ephemeral port."""
+
+        class Server(ThreadingHTTPServer):
+            def handle_error(self, *args: Any) -> None:
+                """Swallows the disconnect tracebacks these tests provoke."""
+
+        cls.server = Server(("127.0.0.1", 0), cls.handler)
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+        cls.base_url = f"http://127.0.0.1:{cls.server.server_address[1]}"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Shuts the server down and releases its port."""
+        cls.server.shutdown()
+        cls.server.server_close()
+
+
 class TestHTTPClient(unittest.TestCase):
     """Test cases for the HTTP client class."""
 
@@ -190,7 +253,7 @@ class TestSessionReuse(unittest.TestCase):
     def test_session_is_pooled_and_retry_configured(self) -> None:
         """Test adapters are mounted with pooling and a backoff retry policy."""
         client = HTTPClient(retries=4)
-        adapter = cast(Any, client.session.get_adapter("https://api.example.com"))
+        adapter = _adapter_of(client, "https://api.example.com")
 
         self.assertEqual(adapter._pool_maxsize, HTTPClient.POOL_SIZE)
         retry = adapter.max_retries
@@ -311,7 +374,7 @@ class TestInjectedSession(unittest.TestCase):
         client = HTTPClient(retries=5, session=session)
 
         self.assertEqual(client.retries, 5)
-        adapter = cast(Any, client.session.get_adapter("https://api.example.com"))
+        adapter = _adapter_of(client, "https://api.example.com")
         self.assertEqual(adapter.max_retries.total, 0)
 
 
@@ -325,16 +388,9 @@ class TestRetryPolicy(unittest.TestCase):
     retries connection errors for every method.
     """
 
-    @staticmethod
-    def _retry(total: int = 3) -> Retry:
-        adapter = cast(
-            Any, HTTPClient(retries=total + 1).session.get_adapter("http://x")
-        )
-        return cast(Retry, adapter.max_retries)
-
     def test_connection_errors_retry_for_non_idempotent_methods(self) -> None:
         """Test a POST is retried on connect failure: nothing reached the server."""
-        retry = self._retry()
+        retry = _policy_for(4)
         # Does not raise -> the attempt is retried.
         retry.increment(method="POST", error=ConnectTimeoutError())
 
@@ -344,25 +400,25 @@ class TestRetryPolicy(unittest.TestCase):
 
     def test_read_errors_do_not_retry_for_non_idempotent_methods(self) -> None:
         """Test a POST is not replayed after a read failure: it may have landed."""
-        retry = self._retry()
+        retry = _policy_for(4)
         # urllib3 re-raises the original error rather than retrying.
         with self.assertRaises(ReadTimeoutError):
             retry.increment(method="POST", error=self._read_error())
 
     def test_read_errors_retry_for_idempotent_methods(self) -> None:
         """Test a GET is retried after a read failure."""
-        retry = self._retry()
+        retry = _policy_for(4)
         retry.increment(method="GET", error=self._read_error())
 
     def test_retryable_status_is_retried_only_for_idempotent_methods(self) -> None:
         """Test the 503 allowlist applies to GET but not to POST."""
-        retry = self._retry()
+        retry = _policy_for(4)
         self.assertTrue(retry.is_retry("GET", 503))
         self.assertFalse(retry.is_retry("POST", 503))
 
     def test_dead_end_status_is_never_retried(self) -> None:
         """Test a 404 is not retried for any method."""
-        retry = self._retry()
+        retry = _policy_for(4)
         self.assertFalse(retry.is_retry("GET", 404))
         self.assertFalse(retry.is_retry("POST", 404))
 
@@ -415,17 +471,10 @@ class TestRetryWithoutASocket(unittest.TestCase):
     same behaviour end to end; this is the cheap version of the same question.
     """
 
-    @staticmethod
-    def _policy(attempts: int) -> Retry:
-        """Returns the client's own retry policy, lifted off a default session."""
-        with HTTPClient(retries=attempts) as client:
-            adapter = cast(Any, client.session.get_adapter("http://x"))
-            return cast(Retry, adapter.max_retries)
-
     def _client(self, attempts: int, pool: _NoSocketPool) -> HTTPClient:
         """Returns a client sending through `pool` under the policy for `attempts`."""
         session = requests.Session()
-        session.mount("http://", _NoSocketAdapter(self._policy(attempts), pool))
+        session.mount("http://", _NoSocketAdapter(_policy_for(attempts), pool))
         return HTTPClient(session=session)
 
     def test_post_is_retried_when_the_connection_never_opens(self) -> None:
@@ -455,47 +504,25 @@ class TestRetryWithoutASocket(unittest.TestCase):
         self.assertEqual(pool.attempts, 1)
 
 
-class TestRetryAgainstRealServer(unittest.TestCase):
-    """End-to-end retry behaviour against a real socket, counting real requests."""
+class _CountingHandler(_QuietHandler):
+    """Answers `/flaky` with a 503 and everything else with a 404, counting hits."""
 
-    server: ClassVar[ThreadingHTTPServer]
-    base_url: ClassVar[str]
     hits: ClassVar[list[str]] = []
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        hits = cls.hits
+    def _reply(self) -> None:
+        """Records the request and answers it without ever succeeding."""
+        self.hits.append(f"{self.command} {self.path}")
+        self.send_body(503 if self.path == "/flaky" else 404, b"{}")
 
-        class Handler(BaseHTTPRequestHandler):
-            protocol_version = "HTTP/1.1"
+    do_GET = _reply
+    do_POST = _reply
 
-            def log_message(self, *args: Any) -> None:
-                pass
 
-            def _reply(self) -> None:
-                hits.append(f"{self.command} {self.path}")
-                code = 503 if self.path == "/flaky" else 404
-                body = b"{}"
-                self.send_response(code)
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
+class TestRetryAgainstRealServer(_LocalServerTestCase):
+    """End-to-end retry behaviour against a real socket, counting real requests."""
 
-            do_GET = _reply
-            do_POST = _reply
-
-        class Server(ThreadingHTTPServer):
-            def handle_error(self, *args: Any) -> None:
-                pass
-
-        cls.server = Server(("127.0.0.1", 0), Handler)
-        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
-        cls.base_url = f"http://127.0.0.1:{cls.server.server_address[1]}"
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.server.shutdown()
-        cls.server.server_close()
+    handler = _CountingHandler
+    hits: ClassVar[list[str]] = _CountingHandler.hits
 
     def setUp(self) -> None:
         self.hits.clear()
@@ -529,47 +556,27 @@ class TestRetryAgainstRealServer(unittest.TestCase):
         self.assertEqual(len(self.hits), 4)
 
 
-class TestProgressAgainstRealServer(unittest.TestCase):
+#: Deliberately over `MIN_SIZE_FOR_PROGRESS`, so the progress path is fully live.
+LARGE_BODY = b"snaffle!" * (6 * 1024 * 1024 // 8)
+
+
+class _LargeBodyHandler(_QuietHandler):
+    """Serves `LARGE_BODY` with a `Content-Length`, for any GET."""
+
+    def do_GET(self) -> None:
+        """Answers with the large body."""
+        self.send_body(200, LARGE_BODY)
+
+
+class TestProgressAgainstRealServer(_LocalServerTestCase):
     """The streaming opt-out, verified against a real socket.
 
     A `Session.request` mock cannot show this. The defect it guards was a body
     drained out from under a caller who asked to stream it, and only a real
-    socket has a body to drain. The payload is deliberately over
-    `MIN_SIZE_FOR_PROGRESS`, so the progress path is fully live.
+    socket has a body to drain.
     """
 
-    body: ClassVar[bytes] = b"snaffle!" * (6 * 1024 * 1024 // 8)
-    server: ClassVar[ThreadingHTTPServer]
-    base_url: ClassVar[str]
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        body = cls.body
-
-        class Handler(BaseHTTPRequestHandler):
-            protocol_version = "HTTP/1.1"
-
-            def log_message(self, *args: Any) -> None:
-                pass
-
-            def do_GET(self) -> None:
-                self.send_response(200)
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
-
-        class Server(ThreadingHTTPServer):
-            def handle_error(self, *args: Any) -> None:
-                pass
-
-        cls.server = Server(("127.0.0.1", 0), Handler)
-        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
-        cls.base_url = f"http://127.0.0.1:{cls.server.server_address[1]}"
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.server.shutdown()
-        cls.server.server_close()
+    handler = _LargeBodyHandler
 
     def test_explicit_stream_leaves_the_body_unread(self) -> None:
         """Test show_progress no longer drains a response asked to stream.
@@ -577,21 +584,32 @@ class TestProgressAgainstRealServer(unittest.TestCase):
         Regression: the progress path ignored the caller's `stream=True` and
         consumed the body anyway, so the returned response had nothing left to
         iterate.
+
+        `_content_consumed` is the assertion that separates the two cases.
+        `iter_content` re-slices an already-buffered body, so it yields the full
+        payload either way -- it cannot tell a live socket from a drained one.
+        The flag is what the API reference documents, so it is the contract.
+        The bar on stderr is the same difference, made visible.
         """
+        stderr = io.StringIO()
         with HTTPClient(show_progress=True) as client:
-            response = client.get(f"{self.base_url}/large", stream=True)
+            with contextlib.redirect_stderr(stderr):
+                response = client.get(f"{self.base_url}/large", stream=True)
 
             self.assertFalse(cast(Any, response)._content_consumed)
-            self.assertEqual(b"".join(response.iter_content(65536)), self.body)
+            self.assertEqual(stderr.getvalue(), "", "no bar is drawn for a stream")
+            self.assertEqual(b"".join(response.iter_content(65536)), LARGE_BODY)
 
     def test_progress_download_returns_a_read_response(self) -> None:
         """Test the buffering path still hands back a fully-read response."""
+        stderr = io.StringIO()
         with HTTPClient(show_progress=True) as client:
-            with contextlib.redirect_stderr(io.StringIO()):  # silence the bar
+            with contextlib.redirect_stderr(stderr):
                 response = client.get(f"{self.base_url}/large")
 
             self.assertTrue(cast(Any, response)._content_consumed)
-            self.assertEqual(response.content, self.body)
+            self.assertIn("%", stderr.getvalue(), "a bar is drawn for a download")
+            self.assertEqual(response.content, LARGE_BODY)
 
 
 if __name__ == "__main__":

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -8,10 +8,12 @@ import threading
 import unittest
 import weakref
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, NoReturn, cast
 from unittest.mock import MagicMock, patch
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.connectionpool import ConnectionPool, HTTPConnectionPool
 from urllib3.exceptions import ConnectTimeoutError, ReadTimeoutError
 from urllib3.util.retry import Retry
 
@@ -28,22 +30,39 @@ class TestHTTPClient(unittest.TestCase):
     """Test cases for the HTTP client class."""
 
     @patch(SESSION_REQUEST)
-    def test_get_request_success(self, mock_request: MagicMock) -> None:
-        """Test a successful GET request."""
-        mock_request.return_value.status_code = 200
-        mock_request.return_value.text = "Success"
+    def test_verb_methods_forward_their_own_method_url_and_kwargs(
+        self, mock_request: MagicMock
+    ) -> None:
+        """Test each verb method delegates with its own method name and the kwargs.
 
-        client = HTTPClient()
-        response = client.get("https://api.example.com")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.text, "Success")
-        # No stream=True: without a progress bar, streaming only holds the
-        # connection open for longer.
-        mock_request.assert_called_once_with(
-            method="GET",
-            url="https://api.example.com",
-            timeout=30,
-        )
+        The seven wrappers carry no behaviour, so this is their whole contract,
+        stated once instead of once per verb. Driving the loop from
+        `ALLOWED_METHODS` also asserts every accepted method has a wrapper.
+
+        Asserting the entire call pins two things besides the delegation: the
+        client's timeout reaches the session, and no `stream=True` is added
+        without a progress bar -- streaming would only hold the connection open
+        for longer.
+        """
+        mock_request.return_value.status_code = 200
+
+        with HTTPClient() as client:
+            for method in sorted(HTTPClient.ALLOWED_METHODS):
+                with self.subTest(method=method):
+                    mock_request.reset_mock()
+                    send = getattr(client, method.lower())
+
+                    response = send(
+                        "https://api.example.com", headers={"X-Verb": method}
+                    )
+
+                    self.assertEqual(response.status_code, 200)
+                    mock_request.assert_called_once_with(
+                        method=method,
+                        url="https://api.example.com",
+                        timeout=30,
+                        headers={"X-Verb": method},
+                    )
 
     @patch(SESSION_REQUEST, side_effect=requests.exceptions.ConnectionError("boom"))
     def test_get_request_connection_failure_maps_to_custom_exception(
@@ -60,31 +79,6 @@ class TestHTTPClient(unittest.TestCase):
         client = HTTPClient()
         with self.assertRaises(HTTPConnectionError):
             client.get("https://api.example.com")
-
-    @patch(SESSION_REQUEST)
-    def test_head_request_success(self, mock_request: MagicMock) -> None:
-        """Test a successful HEAD request."""
-        mock_request.return_value.status_code = 200
-        mock_request.return_value.text = ""
-        client = HTTPClient()
-        response = client.head("https://api.example.com")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.text, "")
-        mock_request.assert_called_once_with(
-            method="HEAD",
-            url="https://api.example.com",
-            timeout=30,
-        )
-
-    @patch(SESSION_REQUEST)
-    def test_options_request_success(self, mock_request: MagicMock) -> None:
-        """Test a successful OPTIONS request."""
-        mock_request.return_value.status_code = 200
-        mock_request.return_value.text = ""
-        client = HTTPClient()
-        response = client.options("https://api.example.com")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.text, "")
 
     @patch(BUFFER_INTO)
     @patch(SESSION_REQUEST)
@@ -240,6 +234,87 @@ class TestSessionReuse(unittest.TestCase):
         client.close()
 
 
+class _RecordingAdapter(HTTPAdapter):
+    """A transport that answers from memory and records what it was asked for.
+
+    Mounted on a session handed to `HTTPClient`, it replaces the network without
+    patching anything.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.requests: list[requests.PreparedRequest] = []
+
+    def send(
+        self,
+        request: requests.PreparedRequest,
+        stream: bool = False,
+        timeout: Any = None,
+        verify: bool | str = True,
+        cert: Any = None,
+        proxies: Any = None,
+    ) -> requests.Response:
+        """Records the request and answers it with a canned 200."""
+        self.requests.append(request)
+        response = requests.Response()
+        response.status_code = 200
+        response.url = request.url or ""
+        response.request = request
+        cast(Any, response)._content = b'{"ok": true}'
+        return response
+
+
+class TestInjectedSession(unittest.TestCase):
+    """The session seam: substituting the transport at the client's own interface.
+
+    `patch("requests.Session.request")` substitutes below this interface and
+    above the adapter, so it cannot see a retry. A session passed to the
+    constructor is substituted at the interface and keeps urllib3's machinery
+    underneath it -- which is what `TestRetryWithoutASocket` uses.
+    """
+
+    def test_an_injected_session_carries_the_request(self) -> None:
+        """Test the client sends through the session it was given."""
+        adapter = _RecordingAdapter()
+        session = requests.Session()
+        session.mount("https://", adapter)
+
+        with HTTPClient(session=session) as client:
+            self.assertIs(client.session, session)
+            response = client.get("https://api.example.com/thing")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"ok": True})
+        self.assertEqual([request.method for request in adapter.requests], ["GET"])
+        self.assertEqual(adapter.requests[0].url, "https://api.example.com/thing")
+
+    def test_an_injected_session_is_not_closed(self) -> None:
+        """Test a session the client did not build stays the caller's to close.
+
+        The caller may be sharing it with other clients, so closing it here
+        would pull the pool out from under them.
+        """
+        session = requests.Session()
+        with patch.object(session, "close") as mock_close:
+            with HTTPClient(session=session) as client:
+                client.close()
+            mock_close.assert_not_called()
+
+    def test_retries_do_not_reach_an_injected_session(self) -> None:
+        """Test `retries` configures the default session and nothing else.
+
+        The retry policy lives on the session's adapters, so a caller who
+        supplies a session supplies the policy along with it. A bare
+        `requests.Session` mounts adapters that do not retry at all.
+        """
+        session = requests.Session()
+        client = HTTPClient(retries=5, session=session)
+
+        self.assertEqual(client.retries, 5)
+        adapter = cast(Any, client.session.get_adapter("https://api.example.com"))
+        self.assertEqual(adapter.max_retries.total, 0)
+
+
 class TestRetryPolicy(unittest.TestCase):
     """Retry behaviour exercised against the real urllib3 machinery.
 
@@ -290,6 +365,94 @@ class TestRetryPolicy(unittest.TestCase):
         retry = self._retry()
         self.assertFalse(retry.is_retry("GET", 404))
         self.assertFalse(retry.is_retry("POST", 404))
+
+
+class _NoSocketPool(HTTPConnectionPool):
+    """A real urllib3 pool whose every connection attempt fails, without a socket.
+
+    urllib3 runs its retry loop inside `HTTPConnectionPool.urlopen`, so the loop
+    only turns if the pool is real. `_new_conn` is the last step before a socket
+    is opened; failing there counts attempts and opens nothing. It is private to
+    urllib3, which is the price of watching the loop from outside.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("127.0.0.1", 9)
+        self.attempts = 0
+
+    def _new_conn(self) -> NoReturn:
+        """Counts the attempt and fails it as if the connection had timed out."""
+        self.attempts += 1
+        raise ConnectTimeoutError("no socket is opened by this test double")
+
+
+class _NoSocketAdapter(HTTPAdapter):
+    """A real adapter, carrying a real retry policy, over `_NoSocketPool`."""
+
+    def __init__(self, retry: Retry, pool: _NoSocketPool) -> None:
+        super().__init__(max_retries=retry)
+        self.no_socket_pool = pool
+
+    def get_connection_with_tls_context(
+        self,
+        request: requests.PreparedRequest,
+        verify: bool | str | None,
+        proxies: Any = None,
+        cert: Any = None,
+    ) -> ConnectionPool:
+        """Hands `requests` the pool that never connects."""
+        return self.no_socket_pool
+
+
+class TestRetryWithoutASocket(unittest.TestCase):
+    """Retry behaviour observed through an injected session, opening no socket.
+
+    Retries happen below `Session.request` and above the socket, so neither a
+    mock of the former nor an assertion about the `Retry` object shows them
+    happening. Injecting a session lets a test put a double at the bottom of
+    that gap instead of the top: the client's own policy, urllib3's real loop,
+    and a pool that counts attempts. `TestRetryAgainstRealServer` proves the
+    same behaviour end to end; this is the cheap version of the same question.
+    """
+
+    @staticmethod
+    def _policy(attempts: int) -> Retry:
+        """Returns the client's own retry policy, lifted off a default session."""
+        with HTTPClient(retries=attempts) as client:
+            adapter = cast(Any, client.session.get_adapter("http://x"))
+            return cast(Retry, adapter.max_retries)
+
+    def _client(self, attempts: int, pool: _NoSocketPool) -> HTTPClient:
+        """Returns a client sending through `pool` under the policy for `attempts`."""
+        session = requests.Session()
+        session.mount("http://", _NoSocketAdapter(self._policy(attempts), pool))
+        return HTTPClient(session=session)
+
+    def test_post_is_retried_when_the_connection_never_opens(self) -> None:
+        """Test a POST is re-attempted on connection failure: nothing was sent.
+
+        This is the claim an earlier revision got wrong against a
+        `Session.request` mock, checked here at the same cost as that mock.
+        """
+        pool = _NoSocketPool()
+        # urllib3 logs a warning per retry; `assertLogs` captures it, which both
+        # keeps the output clean and asserts the retry was announced.
+        with (
+            self.assertLogs("urllib3", "WARNING"),
+            self._client(3, pool) as client,
+            self.assertRaises(HTTPConnectionError),
+        ):
+            client.post("http://never.invalid/thing", json={"a": 1})
+
+        self.assertEqual(pool.attempts, 3)
+
+    def test_a_one_attempt_client_does_not_retry(self) -> None:
+        """Test the attempt count follows the policy rather than the double."""
+        pool = _NoSocketPool()
+        with self._client(1, pool) as client, self.assertRaises(HTTPConnectionError):
+            client.get("http://never.invalid/thing")
+
+        self.assertEqual(pool.attempts, 1)
 
 
 class TestRetryAgainstRealServer(unittest.TestCase):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -19,6 +19,9 @@ from snaffle.exceptions import HTTPConnectionError, ResponseError
 from snaffle.http_client import HTTPClient
 
 SESSION_REQUEST = "requests.Session.request"
+#: Patched where it is used, not where it is defined: `http_client` imports the
+#: name. What it does with a body is `tests/test_download.py`'s business.
+BUFFER_INTO = "snaffle.http_client.buffer_into"
 
 
 class TestHTTPClient(unittest.TestCase):
@@ -83,79 +86,79 @@ class TestHTTPClient(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "")
 
+    @patch(BUFFER_INTO)
     @patch(SESSION_REQUEST)
-    def test_get_request_with_progress(self, mock_request: MagicMock) -> None:
-        """Test GET request with progress enabled streams and buffers content."""
+    def test_get_request_with_progress_streams_and_delegates_the_drain(
+        self, mock_request: MagicMock, mock_buffer_into: MagicMock
+    ) -> None:
+        """Test a progress-enabled GET streams and hands the body to `_download`."""
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.headers = {"content-length": "1024"}
-        mock_response.iter_content.return_value = [b"data"] * 4
         mock_request.return_value = mock_response
 
         client = HTTPClient(show_progress=True)
-        with contextlib.redirect_stderr(io.StringIO()):  # silence the progress bar
-            response = client.get("https://api.example.com")
+        response = client.get("https://api.example.com")
 
-        self.assertEqual(response.status_code, 200)
-        mock_response.iter_content.assert_called_once()
-        self.assertEqual(response._content, b"datadatadatadata")
-        self.assertTrue(cast(Any, response)._content_consumed)
+        self.assertIs(response, mock_response)
         self.assertTrue(mock_request.call_args.kwargs["stream"])
+        mock_buffer_into.assert_called_once_with(
+            mock_response,
+            chunk_size=HTTPClient.DOWNLOAD_CHUNK_SIZE,
+            min_size=HTTPClient.MIN_SIZE_FOR_PROGRESS,
+            desc="Downloading https://api.example.com",
+        )
 
+    @patch(BUFFER_INTO)
     @patch(SESSION_REQUEST)
     def test_get_request_without_progress_does_not_stream(
-        self, mock_request: MagicMock
+        self, mock_request: MagicMock, mock_buffer_into: MagicMock
     ) -> None:
-        """Test GET request without progress skips streaming entirely."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {"content-length": "1024"}
-        mock_request.return_value = mock_response
+        """Test GET request without progress neither streams nor drains."""
+        mock_request.return_value.status_code = 200
 
         client = HTTPClient(show_progress=False)
         response = client.get("https://api.example.com")
 
         self.assertEqual(response.status_code, 200)
-        mock_response.iter_content.assert_not_called()
         self.assertNotIn("stream", mock_request.call_args.kwargs)
+        mock_buffer_into.assert_not_called()
 
-    @staticmethod
-    def _get_with_progress(
-        mock_request: MagicMock, content_length: int
-    ) -> tuple[Any, MagicMock]:
-        """Runs a progress-enabled GET and reports whether a bar was drawn."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {"content-length": str(content_length)}
-        mock_response.iter_content.return_value = [b"data"] * 4
-        mock_request.return_value = mock_response
+    @patch(BUFFER_INTO)
+    @patch(SESSION_REQUEST)
+    def test_explicit_stream_suppresses_the_progress_drain(
+        self, mock_request: MagicMock, mock_buffer_into: MagicMock
+    ) -> None:
+        """Test `stream=True` wins over `show_progress`, leaving the body unread.
+
+        `TestProgressAgainstRealServer` proves the same thing against a socket;
+        this asserts the client asked for it.
+        """
+        mock_request.return_value.status_code = 200
 
         client = HTTPClient(show_progress=True)
-        with patch("tqdm.tqdm") as mock_tqdm:
-            response = client.get("https://api.example.com")
-        return response, mock_tqdm
+        client.get("https://api.example.com", stream=True)
 
+        self.assertTrue(mock_request.call_args.kwargs["stream"])
+        mock_buffer_into.assert_not_called()
+
+    @patch(BUFFER_INTO)
     @patch(SESSION_REQUEST)
-    def test_progress_bar_is_drawn_above_the_threshold(
-        self, mock_request: MagicMock
+    def test_class_constant_overrides_reach_the_download(
+        self, mock_request: MagicMock, mock_buffer_into: MagicMock
     ) -> None:
-        """Test a 6MB download draws a bar: it is over MIN_SIZE_FOR_PROGRESS."""
-        response, mock_tqdm = self._get_with_progress(mock_request, 6 * 1024 * 1024)
+        """Test the documented subclassing hook still tunes the download."""
 
-        self.assertEqual(response.status_code, 200)
-        mock_tqdm.assert_called_once()
+        class SmallBarClient(HTTPClient):
+            """A subclass with the documented class-attribute overrides applied."""
 
-    @patch(SESSION_REQUEST)
-    def test_progress_bar_is_suppressed_below_the_threshold(
-        self, mock_request: MagicMock
-    ) -> None:
-        """Test a 4MB download draws no bar, but still streams and buffers."""
-        response, mock_tqdm = self._get_with_progress(mock_request, 4 * 1024 * 1024)
+            DOWNLOAD_CHUNK_SIZE = 1024
+            MIN_SIZE_FOR_PROGRESS = 1
 
-        self.assertEqual(response.status_code, 200)
-        mock_tqdm.assert_not_called()
-        # Streaming is driven by show_progress, not by the bar existing.
-        cast(Any, response).iter_content.assert_called_once()
+        mock_request.return_value.status_code = 200
+        SmallBarClient(show_progress=True).get("https://api.example.com")
+
+        self.assertEqual(mock_buffer_into.call_args.kwargs["chunk_size"], 1024)
+        self.assertEqual(mock_buffer_into.call_args.kwargs["min_size"], 1)
 
     @patch(SESSION_REQUEST)
     def test_http_error_maps_to_response_error(self, mock_request: MagicMock) -> None:
@@ -361,6 +364,71 @@ class TestRetryAgainstRealServer(unittest.TestCase):
                     client.get(f"{self.base_url}/missing")
             self.assertIs(client.session.get_adapter(self.base_url), pool)
         self.assertEqual(len(self.hits), 4)
+
+
+class TestProgressAgainstRealServer(unittest.TestCase):
+    """The streaming opt-out, verified against a real socket.
+
+    A `Session.request` mock cannot show this. The defect it guards was a body
+    drained out from under a caller who asked to stream it, and only a real
+    socket has a body to drain. The payload is deliberately over
+    `MIN_SIZE_FOR_PROGRESS`, so the progress path is fully live.
+    """
+
+    body: ClassVar[bytes] = b"snaffle!" * (6 * 1024 * 1024 // 8)
+    server: ClassVar[ThreadingHTTPServer]
+    base_url: ClassVar[str]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        body = cls.body
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args: Any) -> None:
+                pass
+
+            def do_GET(self) -> None:
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        class Server(ThreadingHTTPServer):
+            def handle_error(self, *args: Any) -> None:
+                pass
+
+        cls.server = Server(("127.0.0.1", 0), Handler)
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+        cls.base_url = f"http://127.0.0.1:{cls.server.server_address[1]}"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def test_explicit_stream_leaves_the_body_unread(self) -> None:
+        """Test show_progress no longer drains a response asked to stream.
+
+        Regression: the progress path ignored the caller's `stream=True` and
+        consumed the body anyway, so the returned response had nothing left to
+        iterate.
+        """
+        with HTTPClient(show_progress=True) as client:
+            response = client.get(f"{self.base_url}/large", stream=True)
+
+            self.assertFalse(cast(Any, response)._content_consumed)
+            self.assertEqual(b"".join(response.iter_content(65536)), self.body)
+
+    def test_progress_download_returns_a_read_response(self) -> None:
+        """Test the buffering path still hands back a fully-read response."""
+        with HTTPClient(show_progress=True) as client:
+            with contextlib.redirect_stderr(io.StringIO()):  # silence the bar
+                response = client.get(f"{self.base_url}/large")
+
+            self.assertTrue(cast(Any, response)._content_consumed)
+            self.assertEqual(response.content, self.body)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,10 +16,24 @@ class TestRun(unittest.TestCase):
 
     @patch(CLI_MAIN)
     def test_run_delegates_to_the_cli(self, mock_main: MagicMock) -> None:
-        """Test the entry point calls the CLI and does not touch sys.exit."""
-        run()
+        """Test the entry point calls the CLI and exits with the code it returns."""
+        mock_main.return_value = 0
+
+        with self.assertRaises(SystemExit) as caught:
+            run()
 
         mock_main.assert_called_once_with()
+        self.assertEqual(caught.exception.code, 0)
+
+    @patch(CLI_MAIN)
+    def test_run_exits_with_the_cli_error_code(self, mock_main: MagicMock) -> None:
+        """Test a non-zero code from the CLI reaches the process exit status."""
+        mock_main.return_value = 1
+
+        with self.assertRaises(SystemExit) as caught:
+            run()
+
+        self.assertEqual(caught.exception.code, 1)
 
     @patch(CLI_MAIN, side_effect=KeyboardInterrupt)
     def test_keyboard_interrupt_exits_zero(self, _: MagicMock) -> None:


### PR DESCRIPTION
Four candidates from an architecture review, each implemented by its own agent and verified separately. 66 tests pass; `ruff check`, `ruff format --check` and `mypy --strict` are clean.

## A — Give the progress download its own seam

`make_request` interleaved four concerns, and the progress-bar download was the one without an interface of its own. Its three reaches past the seam — rewriting the caller's `stream` kwarg, writing `response._content`, writing `_content_consumed` — were visible only by reading the function body.

That shape hid a defect. Three documents stated the invariant unconditionally:

> A caller who passes `stream=True` explicitly still gets an unconsumed response.

It was false. `track_progress` ignored the caller's `stream`, so with `show_progress=True` the body was drained anyway and the caller got nothing to iterate. Verified against a live socket, now fixed and pinned by `TestProgressAgainstRealServer`.

The download moved into a private `snaffle._download` module owning the whole decision. `DOWNLOAD_CHUNK_SIZE` and `MIN_SIZE_FOR_PROGRESS` stay public attributes of `HTTPClient`; `ProgressBar` is still importable from `snaffle.http_client`.

## B — Return an exit code from `cli.main`

Exit-code policy was spread across three modules, and `main` returned `None`, so the only way to observe the mapping was to launch a process or assert on `SystemExit`. The mapping therefore lived only as a hand-written table in the CLI reference — and it had drifted: `snaffle GET url -t 0` exits `1` through a `ValueError` from `HTTPClient.__init__`, which none of the three documented buckets covered.

`main` now returns an `int` and `run` is the single process-level exit point. `argparse` keeps exiting `2` from inside `parse_args` — a distinct mechanism, clearer left as one, so it is documented rather than routed through the return value.

Observable behaviour is unchanged: same messages, same codes, same stdout.

## C — Accept a session at the client's interface

Eleven tests substituted the transport by patching `requests.Session.request`, a point below the client's interface and above the adapter where urllib3 retries — so retries were invisible through it. The project once shipped a false claim about `POST` retry behaviour on exactly that mistake, and ADR 0001 accepted the hazard as permanent, mitigating it with documentation.

`HTTPClient` now takes an optional `session`. A client closes only a session it built. `retries` builds the default session only, so it does not reach an injected one — documented rather than rejected, since a caller may legitimately want `client.retries` to describe an adapter they mounted themselves.

ADR 0004 records this. It supersedes only the *mitigation* in ADR 0001's Consequences, not its decision.

## D — Thin the verb-method docstrings

The seven verb methods are shallow by the deletion test, but they stay: matching `requests` is real leverage for callers, and removing them would be a major bump for an ergonomic regression. What was worth fixing is the duplication — each wrapper restated the contract that lives in `make_request`, seven times, free to drift. Each now carries one line pointing at `make_request`.

Three near-copy tests became one `subTest` loop over `ALLOWED_METHODS`, covering all seven verbs instead of three and failing if an accepted method ever lacks a wrapper.

## Reviewer notes

**Part of C's premise was wrong.** An injected session with an adapter double *cannot* observe retries: urllib3's loop lives inside `HTTPConnectionPool.urlopen`, which `HTTPAdapter.send` calls once per request, so a double above it counts `1` whatever the policy says. Reaching the loop needed a real pool whose private `_new_conn` fails. That one private urllib3 name is the price of watching the loop from outside; it is recorded in the double's docstring and in ADR 0004. `TestRetryWithoutASocket` is the part to drop first if a urllib3 upgrade breaks it — the rest of C stands without it.

**Two compatibility notes for the version bump.** Code that embedded `cli.main` and caught `SystemExit` to detect an error must now check the return value; nothing in this repo does, and `main` is not in the documented public API. And A's `stream=True` fix is a behaviour change, filed under Fixed.

**C and D share a commit.** D was launched before C was committed, and both edit `http_client.py` and `tests/test_http_client.py`, so they could not be split afterwards without fabricating the boundary.

**Two follow-ups, deliberately out of scope.** `make_request`'s `Raises:` block and `__init__`'s `Args:` block duplicate the reference docs at larger scale than the verb methods did. And the class `Attributes:` block lists `MIN_SIZE_FOR_PROGRESS` as an instance attribute while omitting `DOWNLOAD_CHUNK_SIZE`, `RETRY_STATUSES` and `POOL_SIZE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)